### PR TITLE
Fixed choice follow up image option

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/ALongForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/ALongForm.kt
@@ -14,7 +14,6 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
-import androidx.core.content.getSystemService
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import de.westnordost.streetcomplete.R
@@ -35,17 +34,18 @@ abstract class ALongForm<T> : AbstractOsmQuestForm<T>() {
     protected abstract val items: T
     protected abstract val multiselectItems : List<Quest>
 
-    private var imageUrl : String? = null
+    private var imageUrls : MutableList<String> = mutableListOf()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        adapter =  LongFormAdapter()
+        adapter =  LongFormAdapter {setCameraIntent()}
     }
 
     override fun onClickOk() {
         val editedItems = adapter.givenItems.filter { it.visible  && it.userInput !=null}
         val tagList : MutableList<Pair<String, String>> = mutableListOf()
-        if (imageUrl !=null){
-            tagList.add(Pair("ext:kartaview_url", imageUrl!!))
+        if (imageUrls.isNotEmpty()){
+            val urls = imageUrls.joinToString(",")
+            tagList.add(Pair("ext:kartaview_url", urls))
         }
 
         if (editedItems.isEmpty()) {
@@ -62,7 +62,7 @@ abstract class ALongForm<T> : AbstractOsmQuestForm<T>() {
                 val currentFocus = recyclerView.findFocus() // Use RecyclerView's context to find focus
 
                 if (currentFocus?.id == editTextId) {
-                    hideKeyboardFrom(recyclerView.context, currentFocus)
+                    hideKeyboardFrom(recyclerView.context, currentFocus) //recyclerView.context
                     currentFocus.clearFocus()
                 }
             }
@@ -84,7 +84,7 @@ abstract class ALongForm<T> : AbstractOsmQuestForm<T>() {
         }
         setVisibilityOfItems()
         binding.recyclerView.adapter = adapter
-        setupRecyclerViewTouchListener(binding.recyclerView,R.id.editText)
+
         binding.submitButton.setOnClickListener {
             onClickOk()
         }
@@ -103,9 +103,9 @@ abstract class ALongForm<T> : AbstractOsmQuestForm<T>() {
     }
 
     override fun onImageUrlReceived(imageUrl: String) {
-        binding.imageUrlTV.visibility = View.VISIBLE
-        this.imageUrl = imageUrl
-        binding.imageUrlTV.text = getSpannableText(imageUrl)
+//        binding.imageUrlTV.visibility = View.VISIBLE
+        this.imageUrls.add(imageUrl)
+//        binding.imageUrlTV.text = getSpannableText(imageUrl)
     }
 
     private fun getSpannableText(imageUrl: String): SpannableString {

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk_long_form/data/LongFormAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk_long_form/data/LongFormAdapter.kt
@@ -4,7 +4,6 @@ import android.app.Dialog
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
@@ -30,7 +29,7 @@ import de.westnordost.streetcomplete.view.image_select.ImageSelectAdapter
 import de.westnordost.streetcomplete.view.image_select.Item2
 import androidx.core.graphics.drawable.toDrawable
 
-class LongFormAdapter<T> :
+class LongFormAdapter<T>(val cameraIntent: () -> Unit) :
     RecyclerView.Adapter<ViewHolder>() {
     var givenItems = emptyList<LongFormQuest>()
     var needRefreshIds = listOf<Int?>()
@@ -293,6 +292,9 @@ class LongFormAdapter<T> :
             binding.list.layoutManager = GridLayoutManager(binding.root.context, 3)
             binding.list.isNestedScrollingEnabled = false
             binding.list.adapter = imageSelectAdapter
+            binding.choiceFollowUp.setOnClickListener {
+                cameraIntent()
+            }
             imageSelectAdapter.selectedIndices = item.selectedIndex?.let { listOf(it) } ?: emptyList()
             imageSelectAdapter.listeners.add(object : ImageSelectAdapter.OnItemSelectionListener {
                 override fun onIndexSelected(index: Int) {
@@ -301,8 +303,14 @@ class LongFormAdapter<T> :
                         item.questId!!,
                         item.questAnswerChoices?.get(index)?.value!!,
                         item.questAnswerChoices,
-                        index
+                        index, binding
                     )
+                    if (!item.questAnswerChoices.get(index)?.choiceFollowUp.isNullOrBlank()){
+                        binding.choiceFollowUp.visibility = View.VISIBLE
+                        binding.choiceFollowUp.text = item.questAnswerChoices[index]?.choiceFollowUp
+                    }else{
+                        binding.choiceFollowUp.visibility = View.GONE
+                    }
                 }
 
                 override fun onIndexDeselected(index: Int) {
@@ -325,7 +333,8 @@ class LongFormAdapter<T> :
             questId: Int,
             userInput: String,
             questAnswerChoices: List<QuestAnswerChoice?>,
-            imageIndex: Int
+            imageIndex: Int,
+            binding: CellLongFormItemImageGridBinding
         ) {
             val index =
                 givenItems.indexOfFirst { it.questId == questId }

--- a/app/src/main/res/layout/cell_long_form_item_image_grid.xml
+++ b/app/src/main/res/layout/cell_long_form_item_image_grid.xml
@@ -37,4 +37,22 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/description" />
+
+    <TextView
+        android:id="@+id/choice_follow_up"
+        android:layout_margin="16dp"
+        app:drawableTopCompat="@drawable/ic_camera_outlined"
+        app:drawableTint="@color/button_white"
+        android:padding="8dp"
+        android:textColor="@color/button_white"
+        android:textAlignment="center"
+        android:textSize="16sp"
+        android:visibility="gone"
+        tools:text="Please take a picture of the narrowest place on this sidewalk"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/list"
+        android:background="@color/primary_variant"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This pull request introduces several updates to the `ALongForm` and `AbstractOsmQuestForm` classes, as well as related files, focusing on refactoring, feature enhancements, and code cleanup. Key changes include replacing the compass implementation, refactoring image handling, and improving the `LongFormAdapter` for better functionality and user interaction.

### Refactoring and Feature Enhancements:

* Replaced the manual compass implementation in `AbstractOsmQuestForm` with a dedicated `Compass` class, simplifying code and improving maintainability. 
* Updated image handling in `ALongForm` to support multiple image URLs instead of a single URL, allowing for better flexibility in managing images. 
* 
### Code Cleanup:

* Removed unused imports and redundant code across multiple files, including `AbstractOsmQuestForm` and `ALongForm`, to improve code readability and reduce clutter.

### UI Improvements:

* Enhanced the `LongFormAdapter` to dynamically show or hide a follow-up choice button based on the selected item's properties, improving user interaction.