### PR TITLE
Db workspace integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -162,7 +162,7 @@ dependencies {
     implementation("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0")
 
     // Jetpack Compose
-    val composeBom = platform("androidx.compose:compose-bom:2024.05.00")
+    val composeBom = platform("androidx.compose:compose-bom:2025.05.00")
     implementation(composeBom)
     androidTestImplementation(composeBom)
     implementation("androidx.compose.material:material")

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsDaoTest.kt
@@ -3,16 +3,24 @@ package de.westnordost.streetcomplete.data.osm.edits
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+import de.westnordost.streetcomplete.data.osm.testutils.mock
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
-import kotlin.test.*
+import org.mockito.Mockito
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class EditElementsDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: EditElementsDao
+    private lateinit var preferences: Preferences
 
     @BeforeTest fun createDao() {
-        dao = EditElementsDao(database)
+        val workspaceId  = 301
+        preferences = mock()
+        Mockito.`when`(preferences.workspaceId).thenReturn(workspaceId)
+        dao = EditElementsDao(database, preferences)
     }
 
     @Test fun get_delete_empty() {

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDaoTest.kt
@@ -25,11 +25,14 @@ import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
 import de.westnordost.streetcomplete.data.osm.osmquests.TestQuestType
 import de.westnordost.streetcomplete.data.osm.osmquests.TestQuestType2
+import de.westnordost.streetcomplete.data.osm.testutils.mock
 import de.westnordost.streetcomplete.data.overlays.OverlayRegistry
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement
 import de.westnordost.streetcomplete.overlays.Overlay
 import de.westnordost.streetcomplete.overlays.Style
+import org.mockito.Mockito
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -40,11 +43,15 @@ import kotlin.test.assertTrue
 
 class ElementEditsDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: ElementEditsDao
+    private lateinit var preferences: Preferences
 
     @BeforeTest fun createDao() {
+        val workspaceId  = 301
+        preferences = mock()
+        Mockito.`when`(preferences.workspaceId).thenReturn(workspaceId)
         val list = listOf(1 to TEST_QUEST_TYPE, 2 to TEST_QUEST_TYPE2)
         val list2 = listOf(1 to TestOverlay)
-        dao = ElementEditsDao(database, AllEditTypes(mutableListOf(QuestTypeRegistry(list), OverlayRegistry(list2))))
+        dao = ElementEditsDao(database, AllEditTypes(mutableListOf(QuestTypeRegistry(list), OverlayRegistry(list2))), preferences)
     }
 
     @Test fun addGet_UpdateElementTagsEdit() {

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDaoTest.kt
@@ -23,9 +23,9 @@ class OsmQuestDaoTest : ApplicationDbTestCase() {
     @Test fun addGet() {
         val q = entry(ElementType.NODE, 123L, "a")
         val key = q.key
-        assertNull(dao.get(key))
+        assertNull(dao.get(key, preferences.workspaceId))
         dao.put(q)
-        assertEquals(q, dao.get(key))
+        assertEquals(q, dao.get(key, preferences.workspaceId))
     }
 
     @Test fun delete() {
@@ -33,7 +33,7 @@ class OsmQuestDaoTest : ApplicationDbTestCase() {
         assertFalse(dao.delete(q.key))
         dao.put(q)
         assertTrue(dao.delete(q.key))
-        assertNull(dao.get(q.key))
+        assertNull(dao.get(q.key, preferences.workspaceId))
     }
 
     @Test fun deleteAll() {
@@ -43,16 +43,16 @@ class OsmQuestDaoTest : ApplicationDbTestCase() {
         dao.putAll(listOf(q1, q2, q3))
         dao.deleteAll(listOf(q1.key, q2.key))
 
-        assertNull(dao.get(q1.key))
-        assertNull(dao.get(q2.key))
-        assertEquals(q3, dao.get(q3.key))
+        assertNull(dao.get(q1.key, preferences.workspaceId))
+        assertNull(dao.get(q2.key, preferences.workspaceId))
+        assertEquals(q3, dao.get(q3.key, preferences.workspaceId))
     }
 
     @Test fun clear() {
         val q1 = entry(questTypeName = "a")
         dao.put(q1)
         dao.clear()
-        assertNull(dao.get(q1.key))
+        assertNull(dao.get(q1.key, preferences.workspaceId))
     }
 
     @Test fun getAllForElements() {

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDaoTest.kt
@@ -5,7 +5,10 @@ import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.osm.testutils.mock
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
+import org.mockito.Mockito
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,17 +18,21 @@ import kotlin.test.assertTrue
 
 class OsmQuestDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: OsmQuestDao
+    private lateinit var preferences: Preferences
 
     @BeforeTest fun createDao() {
-        dao = OsmQuestDao(database)
+        val workspaceId  = 301
+        preferences = mock()
+        Mockito.`when`(preferences.workspaceId).thenReturn(workspaceId)
+        dao = OsmQuestDao(database, preferences)
     }
 
     @Test fun addGet() {
         val q = entry(ElementType.NODE, 123L, "a")
         val key = q.key
-        assertNull(dao.get(key, preferences.workspaceId))
+        assertNull(dao.get(key))
         dao.put(q)
-        assertEquals(q, dao.get(key, preferences.workspaceId))
+        assertEquals(q, dao.get(key))
     }
 
     @Test fun delete() {
@@ -33,7 +40,7 @@ class OsmQuestDaoTest : ApplicationDbTestCase() {
         assertFalse(dao.delete(q.key))
         dao.put(q)
         assertTrue(dao.delete(q.key))
-        assertNull(dao.get(q.key, preferences.workspaceId))
+        assertNull(dao.get(q.key))
     }
 
     @Test fun deleteAll() {
@@ -43,16 +50,16 @@ class OsmQuestDaoTest : ApplicationDbTestCase() {
         dao.putAll(listOf(q1, q2, q3))
         dao.deleteAll(listOf(q1.key, q2.key))
 
-        assertNull(dao.get(q1.key, preferences.workspaceId))
-        assertNull(dao.get(q2.key, preferences.workspaceId))
-        assertEquals(q3, dao.get(q3.key, preferences.workspaceId))
+        assertNull(dao.get(q1.key))
+        assertNull(dao.get(q2.key))
+        assertEquals(q3, dao.get(q3.key))
     }
 
     @Test fun clear() {
         val q1 = entry(questTypeName = "a")
         dao.put(q1)
         dao.clear()
-        assertNull(dao.get(q1.key, preferences.workspaceId))
+        assertNull(dao.get(q1.key))
     }
 
     @Test fun getAllForElements() {
@@ -102,7 +109,7 @@ class OsmQuestDaoTest : ApplicationDbTestCase() {
         elementId: Long = 0L,
         questTypeName: String = "a",
         pos: LatLon = p(0.0, 0.0)
-    ) = BasicOsmQuestDaoEntry(elementType, elementId, questTypeName, pos)
+    ) = BasicOsmQuestDaoEntry(elementType, elementId, questTypeName, pos, preferences.workspaceId!!)
 
     private fun p(x: Double, y: Double): LatLon = LatLon(y, x)
 }

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenDaoTest.kt
@@ -2,11 +2,14 @@ package de.westnordost.streetcomplete.data.osm.osmquests
 
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+import de.westnordost.streetcomplete.data.osm.testutils.mock
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 import de.westnordost.streetcomplete.util.ktx.containsExactlyInAnyOrder
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import org.mockito.Mockito
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,22 +18,30 @@ import kotlin.test.assertTrue
 
 class OsmQuestsHiddenDaoTest : ApplicationDbTestCase() {
     private lateinit var dao: OsmQuestsHiddenDao
+    private lateinit var preferences: Preferences
 
-    @BeforeTest fun createDao() {
-        dao = OsmQuestsHiddenDao(database)
+    @BeforeTest
+    fun createDao() {
+        val workspaceId = 301
+        preferences = mock()
+        Mockito.`when`(preferences.workspaceId).thenReturn(workspaceId)
+        dao = OsmQuestsHiddenDao(database, preferences)
     }
 
-    @Test fun getButNothingIsThere() {
+    @Test
+    fun getButNothingIsThere() {
         assertFalse(dao.contains(OsmQuestKey(ElementType.NODE, 0L, "bla")))
     }
 
-    @Test fun addAndGet() {
+    @Test
+    fun addAndGet() {
         val key = OsmQuestKey(ElementType.NODE, 123L, "bla")
         dao.add(key)
         assertTrue(dao.contains(key))
     }
 
-    @Test fun addGetDelete() {
+    @Test
+    fun addGetDelete() {
         val key = OsmQuestKey(ElementType.NODE, 123L, "bla")
         assertFalse(dao.delete(key))
         dao.add(key)
@@ -38,7 +49,8 @@ class OsmQuestsHiddenDaoTest : ApplicationDbTestCase() {
         assertFalse(dao.contains(key))
     }
 
-    @Test fun getNewerThan() = runBlocking {
+    @Test
+    fun getNewerThan() = runBlocking {
         val keys = listOf(
             OsmQuestKey(ElementType.NODE, 123L, "bla"),
             OsmQuestKey(ElementType.NODE, 124L, "bla")
@@ -51,7 +63,8 @@ class OsmQuestsHiddenDaoTest : ApplicationDbTestCase() {
         assertEquals(keys[1], result.osmQuestKey)
     }
 
-    @Test fun getAllIds() {
+    @Test
+    fun getAllIds() {
         val keys = listOf(
             OsmQuestKey(ElementType.NODE, 123L, "bla"),
             OsmQuestKey(ElementType.NODE, 124L, "bla")
@@ -60,7 +73,8 @@ class OsmQuestsHiddenDaoTest : ApplicationDbTestCase() {
         assertTrue(dao.getAllIds().containsExactlyInAnyOrder(keys))
     }
 
-    @Test fun deleteAll() {
+    @Test
+    fun deleteAll() {
         assertEquals(0, dao.deleteAll())
         val keys = listOf(
             OsmQuestKey(ElementType.NODE, 123L, "bla"),
@@ -72,7 +86,8 @@ class OsmQuestsHiddenDaoTest : ApplicationDbTestCase() {
         assertFalse(dao.contains(keys[1]))
     }
 
-    @Test fun countAll() {
+    @Test
+    fun countAll() {
         assertEquals(0, dao.countAll())
         dao.add(OsmQuestKey(ElementType.NODE, 123L, "bla"))
         assertEquals(1, dao.countAll())

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/testutils/Mockito.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/osm/testutils/Mockito.kt
@@ -1,0 +1,19 @@
+package de.westnordost.streetcomplete.data.osm.testutils
+
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatcher
+import org.mockito.Mockito
+import org.mockito.stubbing.OngoingStubbing
+import org.mockito.stubbing.Stubber
+
+fun <T> eq(obj: T): T = Mockito.eq<T>(obj)
+fun <T> argThat(matcher: (T) -> Boolean): T = Mockito.argThat<T>(ArgumentMatcher(matcher))
+fun <T> any(): T = Mockito.any<T>()
+fun <T> capture(argumentCaptor: ArgumentCaptor<T>): T = argumentCaptor.capture()
+inline fun <reified T : Any> argumentCaptor(): ArgumentCaptor<T> =
+    ArgumentCaptor.forClass(T::class.java)
+
+fun <T> on(methodCall: T): OngoingStubbing<T> = Mockito.`when`(methodCall)
+fun <T> Stubber.on(mock: T): T = this.`when`(mock)
+
+inline fun <reified T> mock(): T = Mockito.mock(T::class.java)

--- a/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/statistics/EditTypeStatisticsDaoTest.kt
+++ b/app/src/androidTest/java/de/westnordost/streetcomplete/data/user/statistics/EditTypeStatisticsDaoTest.kt
@@ -1,15 +1,22 @@
 package de.westnordost.streetcomplete.data.user.statistics
 
 import de.westnordost.streetcomplete.data.ApplicationDbTestCase
+import de.westnordost.streetcomplete.data.osm.testutils.mock
+import de.westnordost.streetcomplete.data.preferences.Preferences
+import org.mockito.Mockito
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class EditTypeStatisticsDaoTest : ApplicationDbTestCase() {
     private lateinit var daoType: EditTypeStatisticsDao
+    private lateinit var preferences: Preferences
 
     @BeforeTest fun createDao() {
-        daoType = EditTypeStatisticsDao(database, EditTypeStatisticsTables.NAME)
+        val workspaceId  = 301
+        preferences = mock()
+        Mockito.`when`(preferences.workspaceId).thenReturn(workspaceId)
+        daoType = EditTypeStatisticsDao(database, EditTypeStatisticsTables.NAME, preferences)
     }
 
     @Test fun getZero() {

--- a/app/src/main/java/de/westnordost/streetcomplete/ApplicationModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ApplicationModule.kt
@@ -72,6 +72,8 @@ val appModule = module {
                         val httpClient = get<HttpClient>() // Inject HttpClient for making requests
                         val environmentManager = get<EnvironmentManager>()
 
+                        if (!preferences.workspaceLogin)
+                            return@refreshTokens null
                         val newAccessToken =
                             refreshJwtToken(httpClient, preferences, environmentManager)
 
@@ -113,6 +115,10 @@ suspend fun refreshJwtToken(
         val tempClient = HttpClient {
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
+            }
+            install(Logging) {
+                logger = Logger.DEFAULT
+                level = LogLevel.ALL
             }
         }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/DatabaseInitializer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/DatabaseInitializer.kt
@@ -264,6 +264,7 @@ object DatabaseInitializer {
             db.exec("ALTER TABLE quest_statistics_current_week ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
             db.exec("ALTER TABLE osm_quests ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
             db.exec("ALTER TABLE osm_quests_hidden ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
+            db.exec("ALTER TABLE osm_edit_elements ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/DatabaseInitializer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/DatabaseInitializer.kt
@@ -29,7 +29,7 @@ import de.westnordost.streetcomplete.data.workspace.WorkSpaceTable
 
 /** Creates the database and upgrades it */
 object DatabaseInitializer {
-    const val DB_VERSION = 19
+    const val DB_VERSION = 20
 
     fun onCreate(db: Database) {
         // OSM notes
@@ -256,6 +256,13 @@ object DatabaseInitializer {
         if (oldVersion <= 18 && newVersion == 19) {
             db.exec("ALTER TABLE work_spaces ADD COLUMN externalAppAccess INTEGER DEFAULT 0")
             db.exec("ALTER TABLE work_spaces ADD COLUMN type varchar(255) DEFAULT ''")
+        }
+
+        if (oldVersion<= 19 && newVersion == 20){
+            db.exec("ALTER TABLE osm_element_edits ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
+            db.exec("ALTER TABLE quest_statistics ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
+            db.exec("ALTER TABLE quest_statistics_current_week ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
+            db.exec("ALTER TABLE osm_quests ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/DatabaseInitializer.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/DatabaseInitializer.kt
@@ -263,6 +263,7 @@ object DatabaseInitializer {
             db.exec("ALTER TABLE quest_statistics ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
             db.exec("ALTER TABLE quest_statistics_current_week ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
             db.exec("ALTER TABLE osm_quests ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
+            db.exec("ALTER TABLE osm_quests_hidden ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
         }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsDao.kt
@@ -4,37 +4,39 @@ import de.westnordost.streetcomplete.data.Database
 import de.westnordost.streetcomplete.data.osm.edits.EditElementsTable.Columns.EDIT_ID
 import de.westnordost.streetcomplete.data.osm.edits.EditElementsTable.Columns.ELEMENT_ID
 import de.westnordost.streetcomplete.data.osm.edits.EditElementsTable.Columns.ELEMENT_TYPE
+import de.westnordost.streetcomplete.data.osm.edits.EditElementsTable.Columns.WORKSPACE_ID
 import de.westnordost.streetcomplete.data.osm.edits.EditElementsTable.NAME
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
+import de.westnordost.streetcomplete.data.preferences.Preferences
 
-class EditElementsDao(private val db: Database) {
+class EditElementsDao(private val db: Database, private val preferences: Preferences) {
 
     fun put(id: Long, elementKeys: List<ElementKey>) {
         db.insertMany(
             NAME,
-            arrayOf(EDIT_ID, ELEMENT_TYPE, ELEMENT_ID),
-            elementKeys.map { arrayOf(id, it.type.name, it.id) }
+            arrayOf(EDIT_ID, ELEMENT_TYPE, ELEMENT_ID, WORKSPACE_ID),
+            elementKeys.map { arrayOf(id, it.type.name, it.id, preferences.workspaceId) }
         )
     }
 
     fun get(id: Long): List<ElementKey> =
-        db.query(NAME, where = "$EDIT_ID = $id") {
+        db.query(NAME, where = "$EDIT_ID = $id AND $WORKSPACE_ID = ${preferences.workspaceId}") {
             ElementKey(ElementType.valueOf(it.getString(ELEMENT_TYPE)), it.getLong(ELEMENT_ID))
         }
 
     fun getAllByElement(elementType: ElementType, elementId: Long): List<Long> =
         db.query(NAME,
-            where = "$ELEMENT_TYPE = ? AND $ELEMENT_ID = ?",
+            where = "$ELEMENT_TYPE = ? AND $ELEMENT_ID = ? AND $WORKSPACE_ID = ${preferences.workspaceId}",
             args = arrayOf(elementType.name, elementId),
             columns = arrayOf(EDIT_ID)
         ) { it.getLong(EDIT_ID) }
 
     fun delete(id: Long): Int =
-        db.delete(NAME, "$EDIT_ID = $id")
+        db.delete(NAME, "$EDIT_ID = $id AND $WORKSPACE_ID = ${preferences.workspaceId}")
 
     fun deleteAll(ids: List<Long>): Int {
         if (ids.isEmpty()) return 0
-        return db.delete(NAME, "$EDIT_ID in (${ids.joinToString(",")})")
+        return db.delete(NAME, "$EDIT_ID in (${ids.joinToString(",")}) AND $WORKSPACE_ID = ${preferences.workspaceId}")
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsTable.kt
@@ -15,6 +15,7 @@ object EditElementsTable {
             ${Columns.EDIT_ID} INTEGER NOT NULL,
             ${Columns.ELEMENT_TYPE} varchar(255) NOT NULL,
             ${Columns.ELEMENT_ID} text NOT NULL,
+            ${Columns.WORKSPACE_ID} text NOT NULL,
             CONSTRAINT same_osm_quest PRIMARY KEY (
                 ${Columns.EDIT_ID},
                 ${Columns.ELEMENT_TYPE},

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/EditElementsTable.kt
@@ -7,6 +7,7 @@ object EditElementsTable {
         const val EDIT_ID = "edit_id"
         const val ELEMENT_TYPE = "element_type"
         const val ELEMENT_ID = "element_id"
+        const val WORKSPACE_ID = "workspace_id"
     }
 
     const val CREATE = """
@@ -17,7 +18,8 @@ object EditElementsTable {
             CONSTRAINT same_osm_quest PRIMARY KEY (
                 ${Columns.EDIT_ID},
                 ${Columns.ELEMENT_TYPE},
-                ${Columns.ELEMENT_ID}
+                ${Columns.ELEMENT_ID},
+                ${Columns.WORKSPACE_ID}
             )
         );
     """
@@ -25,7 +27,8 @@ object EditElementsTable {
     const val INDEX_CREATE = """
         CREATE INDEX osm_edit_elements_index ON $NAME (
             ${Columns.ELEMENT_TYPE},
-            ${Columns.ELEMENT_ID}
+            ${Columns.ELEMENT_ID},
+            ${Columns.WORKSPACE_ID}
         );
     """
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsModule.kt
@@ -16,7 +16,7 @@ val elementEditsModule = module {
     factory { ElementEditsDao(get(), get(), get()) }
     factory { ElementIdProviderDao(get()) }
     factory { OpenChangesetsDao(get()) }
-    factory { EditElementsDao(get()) }
+    factory { EditElementsDao(get(), get()) }
 
     single { OpenChangesetsManager(get(), get(), get(), get()) }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsModule.kt
@@ -13,7 +13,7 @@ val elementEditsModule = module {
     factory { ChangesetAutoCloser(get()) }
     factory { ElementEditUploader(get(), get(), get()) }
 
-    factory { ElementEditsDao(get(), get()) }
+    factory { ElementEditsDao(get(), get(), get()) }
     factory { ElementIdProviderDao(get()) }
     factory { OpenChangesetsDao(get()) }
     factory { EditElementsDao(get()) }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/edits/ElementEditsTable.kt
@@ -14,6 +14,7 @@ object ElementEditsTable {
         const val IS_SYNCED = "synced"
         const val ACTION = "action"
         const val IS_NEAR_USER_LOCATION = "is_near"
+        const val WORKSPACE_ID = "workspace_id"
     }
 
     const val CREATE = """
@@ -27,7 +28,8 @@ object ElementEditsTable {
             ${Columns.CREATED_TIMESTAMP} int NOT NULL,
             ${Columns.IS_SYNCED} int NOT NULL,
             ${Columns.ACTION} text,
-            ${Columns.IS_NEAR_USER_LOCATION} int NOT NULL
+            ${Columns.IS_NEAR_USER_LOCATION} int NOT NULL,
+            ${Columns.WORKSPACE_ID} int NOT NULL
         );
     """
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuest.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuest.kt
@@ -47,6 +47,8 @@ data class OsmQuest(
         // fall through to a single marker in the middle
         listOf(position)
     }
+
+    override var workspaceId : Int = 0
 }
 
 const val MAXIMUM_MARKER_DISTANCE = 400

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestController.kt
@@ -15,11 +15,6 @@ import de.westnordost.streetcomplete.data.osmnotes.Note
 import de.westnordost.streetcomplete.data.osmnotes.edits.NotesWithEditsSource
 import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
-import de.westnordost.streetcomplete.quests.address.AddHousenumber
-import de.westnordost.streetcomplete.quests.cycleway.AddCycleway
-import de.westnordost.streetcomplete.quests.existence.CheckExistence
-import de.westnordost.streetcomplete.quests.opening_hours.AddOpeningHours
-import de.westnordost.streetcomplete.quests.place_name.AddPlaceName
 import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.ktx.format
 import de.westnordost.streetcomplete.util.ktx.intersects

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDao.kt
@@ -11,54 +11,69 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestTable.Columns.EL
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestTable.Columns.LATITUDE
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestTable.Columns.LONGITUDE
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestTable.Columns.QUEST_TYPE
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestTable.Columns.WORKSPACE_ID
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestTable.NAME
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.queryIn
 import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 
 /** Persists OsmQuest objects, or more specifically, OsmQuestEntry objects */
-class OsmQuestDao(private val db: Database) {
+class OsmQuestDao(private val db: Database, val preferences: Preferences) {
+
+    private val workspaceId
+        get() = preferences.workspaceId ?: 0
 
     fun put(quest: OsmQuestDaoEntry) {
         db.replace(NAME, quest.toPairs())
     }
 
     fun get(key: OsmQuestKey): OsmQuestDaoEntry? =
-        db.queryOne(NAME,
-            where = "$ELEMENT_TYPE = ? AND $ELEMENT_ID = ? AND $QUEST_TYPE = ?",
-            args = arrayOf(key.elementType.name, key.elementId, key.questTypeName)
+        db.queryOne(
+            NAME,
+            where = "$ELEMENT_TYPE = ? AND $ELEMENT_ID = ? AND $QUEST_TYPE = ? AND $WORKSPACE_ID = ?",
+            args = arrayOf(key.elementType.name, key.elementId, key.questTypeName, workspaceId)
         ) { it.toOsmQuestEntry() }
 
     fun delete(key: OsmQuestKey): Boolean =
-        db.delete(NAME,
-            where = "$ELEMENT_TYPE = ? AND $ELEMENT_ID = ? AND $QUEST_TYPE = ?",
-            args = arrayOf(key.elementType.name, key.elementId, key.questTypeName)
+        db.delete(
+            NAME,
+            where = "$ELEMENT_TYPE = ? AND $ELEMENT_ID = ? AND $QUEST_TYPE = ? AND $WORKSPACE_ID = ?",
+            args = arrayOf(key.elementType.name, key.elementId, key.questTypeName, workspaceId)
         ) == 1
 
     fun putAll(quests: Collection<OsmQuestDaoEntry>) {
         if (quests.isEmpty()) return
         // replace because even if the quest already exists in DB, the center position might have changed
-        db.replaceMany(NAME,
-            arrayOf(QUEST_TYPE, ELEMENT_TYPE, ELEMENT_ID, LATITUDE, LONGITUDE),
-            quests.map { arrayOf(
-                it.questTypeName,
-                it.elementType.name,
-                it.elementId,
-                it.position.latitude,
-                it.position.longitude
-            ) }
+        db.replaceMany(
+            NAME,
+            arrayOf(QUEST_TYPE, ELEMENT_TYPE, ELEMENT_ID, LATITUDE, LONGITUDE, WORKSPACE_ID),
+            quests.map {
+                arrayOf(
+                    it.questTypeName,
+                    it.elementType.name,
+                    it.elementId,
+                    it.position.latitude,
+                    it.position.longitude,
+                    workspaceId
+                )
+            }
         )
     }
 
     fun getAllForElements(keys: Collection<ElementKey>): List<OsmQuestDaoEntry> {
         if (keys.isEmpty()) return emptyList()
-        return db.queryIn(NAME,
-            whereColumns = arrayOf(ELEMENT_TYPE, ELEMENT_ID),
-            whereArgs = keys.map { arrayOf(it.type.name, it.id) }
+        return db.queryIn(
+            NAME,
+            whereColumns = arrayOf(ELEMENT_TYPE, ELEMENT_ID, WORKSPACE_ID),
+            whereArgs = keys.map { arrayOf(it.type.name, it.id, workspaceId) }
         ) { it.toOsmQuestEntry() }
     }
 
-    fun getAllInBBox(bounds: BoundingBox, questTypes: Collection<String>? = null): List<OsmQuestDaoEntry> {
-        var builder = inBoundsSql(bounds)
+    fun getAllInBBox(
+        bounds: BoundingBox,
+        questTypes: Collection<String>? = null
+    ): List<OsmQuestDaoEntry> {
+        var builder = inBoundsSql(bounds, workspaceId)
         if (questTypes != null) {
             if (questTypes.isEmpty()) return emptyList()
             val questTypesStr = questTypes.joinToString(",") { "'$it'" }
@@ -81,16 +96,17 @@ class OsmQuestDao(private val db: Database) {
     }
 }
 
-private fun inBoundsSql(bbox: BoundingBox): String = """
+private fun inBoundsSql(bbox: BoundingBox, workspaceId: Int): String = """
     ($LATITUDE BETWEEN ${bbox.min.latitude} AND ${bbox.max.latitude}) AND
-    ($LONGITUDE BETWEEN ${bbox.min.longitude} AND ${bbox.max.longitude})
+    ($LONGITUDE BETWEEN ${bbox.min.longitude} AND ${bbox.max.longitude}) AND $WORKSPACE_ID = $workspaceId
 """.trimIndent()
 
 private fun CursorPosition.toOsmQuestEntry(): OsmQuestDaoEntry = BasicOsmQuestDaoEntry(
     ElementType.valueOf(getString(ELEMENT_TYPE)),
     getLong(ELEMENT_ID),
     getString(QUEST_TYPE),
-    LatLon(getDouble(LATITUDE), getDouble(LONGITUDE))
+    LatLon(getDouble(LATITUDE), getDouble(LONGITUDE)),
+    getInt(WORKSPACE_ID)
 )
 
 private fun OsmQuestDaoEntry.toPairs() = listOf(
@@ -98,12 +114,14 @@ private fun OsmQuestDaoEntry.toPairs() = listOf(
     ELEMENT_TYPE to elementType.name,
     ELEMENT_ID to elementId,
     LATITUDE to position.latitude,
-    LONGITUDE to position.longitude
+    LONGITUDE to position.longitude,
+    WORKSPACE_ID to workspaceId
 )
 
 data class BasicOsmQuestDaoEntry(
     override val elementType: ElementType,
     override val elementId: Long,
     override val questTypeName: String,
-    override val position: LatLon
+    override val position: LatLon,
+    override val workspaceId: Int
 ) : OsmQuestDaoEntry

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDaoEntry.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDaoEntry.kt
@@ -9,6 +9,7 @@ interface OsmQuestDaoEntry {
     val elementType: ElementType
     val elementId: Long
     val position: LatLon
+    val workspaceId : Int
 }
 
 val OsmQuestDaoEntry.key get() =

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestModule.kt
@@ -5,7 +5,7 @@ import org.koin.dsl.module
 
 val osmQuestModule = module {
     factory { OsmQuestDao(get(), get()) }
-    factory { OsmQuestsHiddenDao(get()) }
+    factory { OsmQuestsHiddenDao(get(), get()) }
 
     single<OsmQuestSource> { get<OsmQuestController>() }
     single<OsmQuestsHiddenSource> { get<OsmQuestController>() }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestModule.kt
@@ -4,7 +4,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val osmQuestModule = module {
-    factory { OsmQuestDao(get()) }
+    factory { OsmQuestDao(get(), get()) }
     factory { OsmQuestsHiddenDao(get()) }
 
     single<OsmQuestSource> { get<OsmQuestController>() }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestTable.kt
@@ -9,6 +9,7 @@ object OsmQuestTable {
         const val ELEMENT_TYPE = "element_type"
         const val LATITUDE = "latitude"
         const val LONGITUDE = "longitude"
+        const val WORKSPACE_ID = "workspace_id"
     }
 
     const val CREATE = """
@@ -18,6 +19,7 @@ object OsmQuestTable {
             ${Columns.ELEMENT_TYPE} varchar(255) NOT NULL,
             ${Columns.LATITUDE} double NOT NULL,
             ${Columns.LONGITUDE} double NOT NULL,
+            ${Columns.WORKSPACE_ID} int NOT NULL,
             PRIMARY KEY (
                 ${Columns.ELEMENT_TYPE},
                 ${Columns.ELEMENT_ID},

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenTable.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenTable.kt
@@ -8,6 +8,7 @@ object OsmQuestsHiddenTable {
         const val ELEMENT_ID = "element_id"
         const val ELEMENT_TYPE = "element_type"
         const val TIMESTAMP = "timestamp"
+        const val WORKSPACE_ID = "workspace_id"
     }
 
     const val CREATE = """
@@ -16,10 +17,12 @@ object OsmQuestsHiddenTable {
             ${Columns.ELEMENT_ID} int NOT NULL,
             ${Columns.ELEMENT_TYPE} varchar(255) NOT NULL,
             ${Columns.TIMESTAMP} int NOT NULL,
+            ${Columns.WORKSPACE_ID} int NOT NULL,
             CONSTRAINT same_osm_quest PRIMARY KEY (
                 ${Columns.QUEST_TYPE},
                 ${Columns.ELEMENT_ID},
-                ${Columns.ELEMENT_TYPE}
+                ${Columns.ELEMENT_TYPE},
+                ${Columns.WORKSPACE_ID}
             )
         );
     """

--- a/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/quest/QuestModule.kt
@@ -4,5 +4,5 @@ import org.koin.dsl.module
 
 val questModule = module {
     single { QuestAutoSyncer(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
-    single { VisibleQuestsSource(get(), get(), get(), get(), get(), get()) }
+    single { VisibleQuestsSource(get(), get(), get(), get(), get(), get(), get()) }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/UserLoginController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/UserLoginController.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.data.user
 
 import de.westnordost.osmapi.OsmConnection
 import de.westnordost.streetcomplete.data.preferences.Preferences
+import de.westnordost.streetcomplete.screens.settings.SettingsViewModel
 import de.westnordost.streetcomplete.util.Listeners
 
 class UserLoginController(

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/EditTypeStatisticsDao.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/EditTypeStatisticsDao.kt
@@ -2,29 +2,33 @@ package de.westnordost.streetcomplete.data.user.statistics
 
 import de.westnordost.streetcomplete.data.CursorPosition
 import de.westnordost.streetcomplete.data.Database
+import de.westnordost.streetcomplete.data.osm.edits.ElementEditsTable.Columns.WORKSPACE_ID
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.user.statistics.EditTypeStatisticsTables.Columns.ELEMENT_EDIT_TYPE
 import de.westnordost.streetcomplete.data.user.statistics.EditTypeStatisticsTables.Columns.SUCCEEDED
 
 /** Stores how many edits of which element type the user did */
-class EditTypeStatisticsDao(private val db: Database, private val name: String) {
+class EditTypeStatisticsDao(private val db: Database, private val name: String,
+                            private val preferences: Preferences) {
 
     fun getTotalAmount(): Int =
-        db.queryOne(name, arrayOf("total($SUCCEEDED) as count")) { it.getInt("count") } ?: 0
+        db.queryOne(name, arrayOf("total($SUCCEEDED) as count"), where = "$WORKSPACE_ID = ${preferences.workspaceId}") { it.getInt("count") } ?: 0
 
     fun getAll(): List<EditTypeStatistics> =
-        db.query(name) { it.toEditTypeStatistics() }
+        db.query(name, where = "$WORKSPACE_ID = ${preferences.workspaceId}") { it.toEditTypeStatistics() }
 
     fun clear() {
-        db.delete(name)
+        db.delete(name, where = "$WORKSPACE_ID = ${preferences.workspaceId}")
     }
 
     fun replaceAll(amounts: Map<String, Int>) {
         db.transaction {
-            db.delete(name)
+            db.delete(name, where = "$WORKSPACE_ID = ${preferences.workspaceId}")
             if (amounts.isNotEmpty()) {
                 db.replaceMany(name,
-                    arrayOf(ELEMENT_EDIT_TYPE, SUCCEEDED),
-                    amounts.map { arrayOf(it.key, it.value) }
+                    arrayOf(ELEMENT_EDIT_TYPE, SUCCEEDED, WORKSPACE_ID),
+                    amounts.map { arrayOf(it.key, it.value, preferences.workspaceId)
+                    }
                 )
             }
         }
@@ -35,22 +39,23 @@ class EditTypeStatisticsDao(private val db: Database, private val name: String) 
             // first ensure the row exists
             db.insertOrIgnore(name, listOf(
                 ELEMENT_EDIT_TYPE to type,
-                SUCCEEDED to 0
+                SUCCEEDED to 0,
+                WORKSPACE_ID to preferences.workspaceId
             ))
 
             // then increase by one
-            db.exec("UPDATE $name SET $SUCCEEDED = $SUCCEEDED + 1 WHERE $ELEMENT_EDIT_TYPE = ?", arrayOf(type))
+            db.exec("UPDATE $name SET $SUCCEEDED = $SUCCEEDED + 1 WHERE $ELEMENT_EDIT_TYPE = ? AND $WORKSPACE_ID = ${preferences.workspaceId}", arrayOf(type))
         }
     }
 
     fun subtractOne(type: String) {
-        db.exec("UPDATE $name SET $SUCCEEDED = $SUCCEEDED - 1 WHERE $ELEMENT_EDIT_TYPE = ?", arrayOf(type))
+        db.exec("UPDATE $name SET $SUCCEEDED = $SUCCEEDED - 1 WHERE $ELEMENT_EDIT_TYPE = ? AND $WORKSPACE_ID = ${preferences.workspaceId}", arrayOf(type))
     }
 
     fun getAmount(type: String): Int =
         db.queryOne(name,
             columns = arrayOf(SUCCEEDED),
-            where = "$ELEMENT_EDIT_TYPE = ?",
+            where = "$ELEMENT_EDIT_TYPE = ? AND $WORKSPACE_ID = ${preferences.workspaceId}",
             args = arrayOf(type)
         ) { it.getInt(SUCCEEDED) } ?: 0
 
@@ -58,7 +63,7 @@ class EditTypeStatisticsDao(private val db: Database, private val name: String) 
         val questionMarks = Array(type.size) { "?" }.joinToString(",")
         return db.queryOne(name,
             columns = arrayOf("total($SUCCEEDED) as count"),
-            where = "$ELEMENT_EDIT_TYPE in ($questionMarks)",
+            where = "$ELEMENT_EDIT_TYPE in ($questionMarks) AND $WORKSPACE_ID = ${preferences.workspaceId}",
             args = type.toTypedArray()
         ) { it.getInt("count") } ?: 0
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/EditTypeStatisticsTables.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/EditTypeStatisticsTables.kt
@@ -7,12 +7,14 @@ object EditTypeStatisticsTables {
     object Columns {
         const val ELEMENT_EDIT_TYPE = "quest_type"
         const val SUCCEEDED = "succeeded"
+        const val WORKSPACE_ID = "workspace_id"
     }
 
     fun create(name: String) = """
         CREATE TABLE $name (
-            ${Columns.ELEMENT_EDIT_TYPE} varchar(255) PRIMARY KEY,
-            ${Columns.SUCCEEDED} int NOT NULL
+            ${Columns.ELEMENT_EDIT_TYPE} varchar(255),
+            ${Columns.SUCCEEDED} int NOT NULL,
+            ${Columns.WORKSPACE_ID} int NOT NULL
         );
     """
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/user/statistics/StatisticsModule.kt
@@ -6,10 +6,10 @@ import org.koin.dsl.module
 private const val STATISTICS_BACKEND_URL = "https://www.westnordost.de/streetcomplete/statistics/"
 val statisticsModule = module {
 
-    factory(named("EditTypeStatistics")) { EditTypeStatisticsDao(get(), EditTypeStatisticsTables.NAME) }
+    factory(named("EditTypeStatistics")) { EditTypeStatisticsDao(get(), EditTypeStatisticsTables.NAME, get()) }
     factory(named("CountryStatistics")) { CountryStatisticsDao(get(), CountryStatisticsTables.NAME) }
 
-    factory(named("EditTypeStatisticsCurrentWeek")) { EditTypeStatisticsDao(get(), EditTypeStatisticsTables.NAME_CURRENT_WEEK) }
+    factory(named("EditTypeStatisticsCurrentWeek")) { EditTypeStatisticsDao(get(), EditTypeStatisticsTables.NAME_CURRENT_WEEK, get()) }
     factory(named("CountryStatisticsCurrentWeek")) { CountryStatisticsDao(get(), CountryStatisticsTables.NAME_CURRENT_WEEK) }
 
     factory { ActiveDatesDao(get()) }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk_long_form/AddGenericLong.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/sidewalk_long_form/AddGenericLong.kt
@@ -22,7 +22,8 @@ class AddGenericLong(val item: AddLongFormResponseItem) :
     override val icon = when (item.elementType) {
         "Sidewalks" -> R.drawable.ic_quest_sidewalk
         "Crossings" -> R.drawable.ic_quest_pedestrian_crossing
-        else -> R.drawable.ic_quest_kerb_type
+        "Kerb" -> R.drawable.ic_quest_kerb_type
+        else -> R.drawable.ic_quest_notes
     }
     override val achievements = listOf(PEDESTRIAN)
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/debug/ShowQuestFormsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.quest.QuestType
+import de.westnordost.streetcomplete.quests.sidewalk_long_form.AddGenericLong
 import de.westnordost.streetcomplete.screens.settings.genericQuestTitle
 import de.westnordost.streetcomplete.ui.common.BackIcon
 import de.westnordost.streetcomplete.ui.common.CenteredLargeTitleHint
@@ -134,8 +135,14 @@ private fun QuestList(
                         contentDescription = item.name,
                         modifier = Modifier.size(32.dp),
                     )
+
+                    val title = if (item is AddGenericLong){
+                        item.item.elementType!!
+                    }else{
+                        "Create Note"
+                    }
                     Text(
-                        text = genericQuestTitle(item),
+                        text = title,
                         style = MaterialTheme.typography.body1
                     )
                 }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionItem.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionItem.kt
@@ -58,10 +58,10 @@ fun QuestSelectionItem(
             verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             var title = ""
-            if (item.questType is AddGenericLong){
-                title = item.questType.item.elementType!!
+            title = if (item.questType is AddGenericLong){
+                item.questType.item.elementType!!
             }else{
-                title = "Create Note"
+                "Create Note"
             }
             Text(
                 text = title,

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileFragment.kt
@@ -6,12 +6,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.material.Surface
 import androidx.fragment.app.Fragment
+import de.westnordost.streetcomplete.screens.settings.SettingsViewModel
 import de.westnordost.streetcomplete.ui.util.composableContent
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class ProfileFragment : Fragment() {
     private val viewModel by viewModel<ProfileViewModel>()
+    private val settingsViewModel by viewModel<SettingsViewModel>()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
-        composableContent { Surface { ProfileScreen(viewModel) } }
+        composableContent { Surface { ProfileScreen(viewModel, settingsViewModel) } }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/user/profile/ProfileScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.sp
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.quests.sidewalk_long_form.data.AddLongFormResponseItem
 import de.westnordost.streetcomplete.screens.MainActivity
+import de.westnordost.streetcomplete.screens.settings.SettingsViewModel
 import de.westnordost.streetcomplete.screens.workspaces.WorkSpaceActivity
 import de.westnordost.streetcomplete.ui.ktx.toDp
 import de.westnordost.streetcomplete.ui.theme.headlineLarge
@@ -54,7 +55,7 @@ import java.util.Locale
 /** Shows the user profile: username, avatar, star count and a hint regarding unpublished changes */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun ProfileScreen(viewModel: ProfileViewModel) {
+fun ProfileScreen(viewModel: ProfileViewModel, settingsViewModel: SettingsViewModel) {
     val userName by viewModel.userName.collectAsState()
     val userAvatarFile by viewModel.userAvatarFile.collectAsState()
 
@@ -126,6 +127,7 @@ fun ProfileScreen(viewModel: ProfileViewModel) {
 //                Text(stringResource(R.string.osm_profile).uppercase())
 //            }
             OutlinedButton(onClick = { viewModel.logOutUser()
+                settingsViewModel.deleteCache()
             finishAndLaunchNewActivity(context)
             }) {
                 Text(stringResource(R.string.user_logout).uppercase())

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/workspaces/WorkSpaceActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/workspaces/WorkSpaceActivity.kt
@@ -82,7 +82,6 @@ class WorkSpaceActivity : ComponentActivity() {
         }
     }
 
-    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -286,7 +285,6 @@ fun AppNavigator(
             fineLocationManager.getCurrentLocation()
             WorkSpaceListScreen(
                 viewModel = koinViewModel(),
-                settingsViewModel = koinViewModel(),
                 modifier = modifier.padding(innerPadding)
             )
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/workspaces/WorkspaceListScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/workspaces/WorkspaceListScreen.kt
@@ -40,7 +40,7 @@ import de.westnordost.streetcomplete.screens.MainActivity
 import de.westnordost.streetcomplete.screens.settings.SettingsViewModel
 
 @Composable
-fun WorkSpaceListScreen(viewModel: WorkspaceViewModel, settingsViewModel: SettingsViewModel, modifier: Modifier = Modifier) {
+fun WorkSpaceListScreen(viewModel: WorkspaceViewModel, modifier: Modifier = Modifier) {
     val workspaceListState by viewModel.showWorkspaces.collectAsState()
     var isLoading by remember { mutableStateOf(false) }
     var isLongFormLoading by remember { mutableStateOf(false) }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/workspaces/WorkspaceListScreen.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/workspaces/WorkspaceListScreen.kt
@@ -129,7 +129,7 @@ fun WorkSpaceListScreen(viewModel: WorkspaceViewModel, settingsViewModel: Settin
                             isLongFormLoading = false
                             viewModel.setIsLongForm(true)
                             snackBarMessage = null
-                            settingsViewModel.deleteMapQuests()
+//                            settingsViewModel.deleteMapQuests()
                             finishAndLaunchNewActivity(context, longFormState.longFormItems)
                         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1786,8 +1786,8 @@ Alternatively, you can leave a note (with a photo)."</string>
     <string name="lane_narrowing_traffic_calming_none">No narrowed lane here</string>
 
     <!--    Adding for GIG-->
-    <string name="email">Email</string>
-    <string name="password">Password</string>
+    <string name="email">Email for %1$s</string>
+    <string name="password">Password for %1$s</string>
     <string name="title_activity_work_space">WorkSpaceActivity</string>
     <string name="quest_kerb_title">Is there a curb here</string>
     <string name="submit">Submit</string>

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestControllerTest.kt
@@ -90,7 +90,7 @@ class OsmQuestControllerTest {
         val entry = questEntry(NODE, 1, "ApplicableQuestType")
         val g = pGeom()
 
-        on(db.get(osmQuestKey(NODE, 1, "ApplicableQuestType"), preferences.workspaceId)).thenReturn(entry)
+        on(db.get(osmQuestKey(NODE, 1, "ApplicableQuestType"))).thenReturn(entry)
         on(mapDataSource.getGeometry(NODE, 1)).thenReturn(g)
 
         val expectedQuest = OsmQuest(ApplicableQuestType, NODE, 1, g)
@@ -194,7 +194,7 @@ class OsmQuestControllerTest {
         on(hiddenDB.delete(quest.key)).thenReturn(true)
         on(hiddenDB.getTimestamp(eq(quest.key))).thenReturn(555)
         on(mapDataSource.getGeometry(quest.elementType, quest.elementId)).thenReturn(pGeom())
-        on(db.get(quest.key, preferences.workspaceId)).thenReturn(quest)
+        on(db.get(quest.key)).thenReturn(quest)
 
         assertTrue(ctrl.unhide(quest.key))
 
@@ -363,8 +363,9 @@ private fun questEntry(
     elementType: ElementType = NODE,
     elementId: Long = 1,
     questTypeName: String = "ApplicableQuestType",
-    position: LatLon = p()
-): OsmQuestDaoEntry = BasicOsmQuestDaoEntry(elementType, elementId, questTypeName, position)
+    position: LatLon = p(),
+    workspaceId: Int = 0
+): OsmQuestDaoEntry = BasicOsmQuestDaoEntry(elementType, elementId, questTypeName, position, workspaceId)
 
 private object ApplicableQuestType : TestQuestTypeA() {
     override fun isApplicableTo(element: Element) = true

--- a/app/src/test/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestControllerTest.kt
@@ -90,7 +90,7 @@ class OsmQuestControllerTest {
         val entry = questEntry(NODE, 1, "ApplicableQuestType")
         val g = pGeom()
 
-        on(db.get(osmQuestKey(NODE, 1, "ApplicableQuestType"))).thenReturn(entry)
+        on(db.get(osmQuestKey(NODE, 1, "ApplicableQuestType"), preferences.workspaceId)).thenReturn(entry)
         on(mapDataSource.getGeometry(NODE, 1)).thenReturn(g)
 
         val expectedQuest = OsmQuest(ApplicableQuestType, NODE, 1, g)
@@ -194,7 +194,7 @@ class OsmQuestControllerTest {
         on(hiddenDB.delete(quest.key)).thenReturn(true)
         on(hiddenDB.getTimestamp(eq(quest.key))).thenReturn(555)
         on(mapDataSource.getGeometry(quest.elementType, quest.elementId)).thenReturn(pGeom())
-        on(db.get(quest.key)).thenReturn(quest)
+        on(db.get(quest.key, preferences.workspaceId)).thenReturn(quest)
 
         assertTrue(ctrl.unhide(quest.key))
 

--- a/app/src/test/java/de/westnordost/streetcomplete/data/quest/VisibleQuestsSourceTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/quest/VisibleQuestsSourceTest.kt
@@ -9,6 +9,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestSource
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuest
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestSource
 import de.westnordost.streetcomplete.data.overlays.SelectedOverlaySource
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.visiblequests.TeamModeQuestFilter
 import de.westnordost.streetcomplete.data.visiblequests.VisibleQuestTypeSource
 import de.westnordost.streetcomplete.overlays.Overlay
@@ -21,6 +22,7 @@ import de.westnordost.streetcomplete.testutils.osmNoteQuest
 import de.westnordost.streetcomplete.testutils.osmQuest
 import de.westnordost.streetcomplete.testutils.osmQuestKey
 import de.westnordost.streetcomplete.testutils.pGeom
+import org.mockito.Mockito
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import kotlin.test.BeforeTest
@@ -49,8 +51,12 @@ class VisibleQuestsSourceTest {
     private val bbox = bbox(0.0, 0.0, 1.0, 1.0)
     private val questTypes = listOf(TestQuestTypeA(), TestQuestTypeB(), TestQuestTypeC())
     private val questTypeNames = questTypes.map { it.name }
+    private lateinit var preferences: Preferences
 
     @BeforeTest fun setUp() {
+        val workspaceId  = 301
+        preferences = mock()
+        Mockito.`when`(preferences.workspaceId).thenReturn(workspaceId)
         osmNoteQuestSource = mock()
         osmQuestSource = mock()
         visibleQuestTypeSource = mock()
@@ -82,7 +88,7 @@ class VisibleQuestsSourceTest {
             Unit
         }
 
-        source = VisibleQuestsSource(questTypeRegistry, osmQuestSource, osmNoteQuestSource, visibleQuestTypeSource, teamModeQuestFilter, selectedOverlaySource)
+        source = VisibleQuestsSource(questTypeRegistry, osmQuestSource, osmNoteQuestSource, visibleQuestTypeSource, teamModeQuestFilter, selectedOverlaySource, preferences)
 
         listener = mock()
         source.addListener(listener)

--- a/app/src/test/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsControllerTest.kt
+++ b/app/src/test/java/de/westnordost/streetcomplete/data/user/achievements/AchievementsControllerTest.kt
@@ -268,7 +268,6 @@ private object QuestOne : QuestType {
     override val wikiLink: String? = null
     override fun createForm(): AbstractQuestForm = mock()
     override val achievements = editTypeAchievements(listOf("thisAchievement", "mixedAchievement"))
-    override fun createMultiSelectLongForm(selectedQuests: List<Quest>): AbstractQuestForm = mock()
 }
 
 private object QuestTwo : QuestType {
@@ -277,7 +276,6 @@ private object QuestTwo : QuestType {
     override val wikiLink: String? = null
     override fun createForm(): AbstractQuestForm = mock()
     override val achievements = editTypeAchievements(listOf("otherAchievement", "mixedAchievement"))
-    override fun createMultiSelectLongForm(selectedQuests: List<Quest>): AbstractQuestForm = mock()
 }
 
 private object OverlayOne : Overlay {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         val kotlinVersion = "2.0.0"
-        classpath("com.android.tools.build:gradle:8.9.1")
+        classpath("com.android.tools.build:gradle:8.9.2")
         classpath(kotlin("gradle-plugin", version = kotlinVersion))
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to enhance database functionality by adding workspace-specific support, updating dependencies, and improving test utilities and logging. The key updates include schema modifications, dependency upgrades, and adjustments to accommodate workspace IDs in various database operations.

### Database Enhancements:
* Updated `DatabaseInitializer` to increase the database version to 20 and added new `workspace_id` columns to multiple tables (`osm_element_edits`, `quest_statistics`, `quest_statistics_current_week`, `osm_quests`, `osm_quests_hidden`, and `osm_edit_elements`) to support workspace-specific data. [[1]](diffhunk://#diff-ca07f9dc2cc8bbf5dd6e14857c3cad8ea8b85667365d5cc102c7aabd308ae950L32-R32) [[2]](diffhunk://#diff-ca07f9dc2cc8bbf5dd6e14857c3cad8ea8b85667365d5cc102c7aabd308ae950R260-R268)
* Modified `EditElementsTable` and `ElementEditsTable` schemas to include `workspace_id` as a required field and updated their primary keys and indexes accordingly. [[1]](diffhunk://#diff-db740bef407322cd6537a8e7fb9945c43cb1b9f38d6e153c0b2d14397bbc8a09R10-R32) [[2]](diffhunk://#diff-05a7cbe8b19ef83645b529211d8ab7701487b2a90a0ba2815d36ae9e9f47a2daR16)

### Dependency Updates:
* Upgraded the Jetpack Compose BOM dependency in `app/build.gradle.kts` from version `2024.05.00` to `2025.05.00`.

### Code Changes for Workspace Support:
* Updated DAOs (`EditElementsDao`, `ElementEditsDao`, `OsmQuestDao`, `OsmQuestsHiddenDao`, and `EditTypeStatisticsDao`) to include `Preferences` for accessing `workspace_id` and to filter database queries by the current workspace. [[1]](diffhunk://#diff-84e6701f22b0e201439a71e31e01e8f6148713791ec0f13a180835da6c45cd1cR7-R40) [[2]](diffhunk://#diff-05a7cbe8b19ef83645b529211d8ab7701487b2a90a0ba2815d36ae9e9f47a2daR39) [[3]](diffhunk://#diff-381deef9c705056ac592bcf9a43cef61b89b1a8ffb323a73bf32da2edbcd47e7R21-R27) [[4]](diffhunk://#diff-d5fe283a0bf7fbe7756d140dbf489e1c2e5092938bc681bdcb16accd922ef91eR21-R53) [[5]](diffhunk://#diff-16960372f343fab0992c32b9cae5bf9cc4e85d27e47dbee7eb8cdcfe286860cfR4-R19)

### Test Utilities and Logging:
* Added a new `Mockito.kt` utility file to simplify mocking in tests, including functions like `mock()`, `on()`, and `argThat()`.
* Enabled detailed HTTP request logging in `refreshJwtToken` using the `Logging` feature from Ktor.

### Application Logic:
* Added a condition in `ApplicationModule` to return `null` if `workspaceLogin` is disabled during token refresh operations.