### PR TITLE
Fix image select text shadow, add long press to zoom image

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/workspace/data/remote/WorkspaceConstants.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/workspace/data/remote/WorkspaceConstants.kt
@@ -12,19 +12,19 @@ enum class Environment(
         "https://api.workspaces-stage.sidewalks.washington.edu/api/v1/workspaces",
         "https://tdei-gateway-stage.azurewebsites.net/api/v1",
         "https://tdei-usermanagement-stage.azurewebsites.net/api/v1/user-profile",
-        "https://osm.workspaces-stage.sidewalks.washington.edu/api/0.6/"
+        "https://osm-workspaces-proxy.azurewebsites.net/stage/api/0.6/"
     ),
     DEV(
         "https://api.workspaces-dev.sidewalks.washington.edu/api/v1/workspaces",
         "https://tdei-api-dev.azurewebsites.net/api/v1",
         "https://tdei-usermanagement-be-dev.azurewebsites.net/api/v1/user-profile",
-        "https://osm.workspaces-dev.sidewalks.washington.edu/api/0.6/"
+        "https://osm-workspaces-proxy.azurewebsites.net/dev/api/0.6/"
     ),
     PROD(
         "https://api.workspaces.sidewalks.washington.edu/api/v1/workspaces",
         "https://tdei-gateway-prod.azurewebsites.net/api/v1",
         "https://tdei-usermanagement-prod.azurewebsites.net/api/v1/user-profile",
-        "https://osm.workspaces.sidewalks.washington.edu/api/0.6/"
+        "https://osm-workspaces-proxy.azurewebsites.net/prod/api/0.6/"
     ),
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/view/image_select/ImageSelectAdapter.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/image_select/ImageSelectAdapter.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete.view.image_select
 
+import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
@@ -17,7 +18,8 @@ class ImageSelectAdapter<T>(private val maxSelectableIndices: Int = -1) :
         }
 
     private val _selectedIndices = mutableSetOf<Int>()
-    var selectedIndices get() = _selectedIndices.toList()
+    var selectedIndices
+        get() = _selectedIndices.toList()
         set(value) {
             _selectedIndices.clear()
             _selectedIndices.addAll(value)
@@ -31,6 +33,9 @@ class ImageSelectAdapter<T>(private val maxSelectableIndices: Int = -1) :
     interface OnItemSelectionListener {
         fun onIndexSelected(index: Int)
         fun onIndexDeselected(index: Int)
+        fun onLongPress(index: Int, drawable: Drawable?) {
+
+        }
     }
 
     fun indexOf(item: T): Int = items.indexOfFirst { it.value == item }
@@ -45,7 +50,13 @@ class ImageSelectAdapter<T>(private val maxSelectableIndices: Int = -1) :
         val view = LayoutInflater.from(parent.context).inflate(cellLayoutId, parent, false)
         val holder = ItemViewHolder(view)
         holder.onClickListener = ::toggle
+        holder.onLongClickListener = ::longPress
         return holder
+    }
+
+    private fun longPress(index: Int, drawable: Drawable?) {
+        checkIndexRange(index)
+        listeners.forEach { it.onLongPress(index, drawable) }
     }
 
     fun isSelected(index: Int) = _selectedIndices.contains(index)

--- a/app/src/main/java/de/westnordost/streetcomplete/view/image_select/ItemViewHolder.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/image_select/ItemViewHolder.kt
@@ -1,32 +1,28 @@
 package de.westnordost.streetcomplete.view.image_select
 
-import android.app.Dialog
-import android.graphics.Color
+import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.compose.ui.res.colorResource
-import androidx.core.graphics.drawable.toDrawable
-import androidx.core.view.ViewCompat
-import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.isGone
 import androidx.recyclerview.widget.RecyclerView
-import com.github.chrisbanes.photoview.PhotoView
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.view.ImageUrl
 import de.westnordost.streetcomplete.view.setImage
 import de.westnordost.streetcomplete.view.setText
 
 class ItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
     private val imageView: ImageView? = itemView.findViewById(R.id.imageView)
-    private val textView: TextView? = itemView.findViewById(R.id.textView)
+    private val textView: OutlinedTextView? = itemView.findViewById(R.id.textView)
     private val descriptionView: TextView? = itemView.findViewById(R.id.descriptionView)
-    private val dropDownArrowImageView: ImageView? = itemView.findViewById(R.id.dropDownArrowImageView)
+    private val dropDownArrowImageView: ImageView? =
+        itemView.findViewById(R.id.dropDownArrowImageView)
 
     var isSelected: Boolean
         get() = itemView.isSelected
-        set(value) { itemView.isSelected = value }
+        set(value) {
+            itemView.isSelected = value
+        }
 
     var isGroupExpanded: Boolean = false
         set(value) {
@@ -47,49 +43,24 @@ class ItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
             }
         }
 
+    var onLongClickListener: ((index: Int, drawable: Drawable?) -> Unit)? = null
+        set(value) {
+            field = value
+            if (value == null) {
+                itemView.setOnLongClickListener(null)
+            } else {
+                itemView.setOnLongClickListener {
+                    val index = adapterPosition
+                    if (index != RecyclerView.NO_POSITION) value.invoke(index, imageView?.drawable)
+                    false
+                }
+            }
+        }
+
     fun bind(item: DisplayItem<*>) {
         imageView?.setImage(item.image)
         textView?.setText(item.title)
-        if (item.image == null || (item.image is ImageUrl && ((item.image as ImageUrl).url.isNullOrEmpty()))) {
-            textView?.setTextColor(textView.context.resources.getColor(R.color.text))
-            textView?.setShadowLayer(20f, 0f, 0f, textView.context.resources.getColor(android.R.color.transparent))
-        }else{
-            textView?.setTextColor(textView.context.resources.getColor(R.color.button_white))
-            textView?.setShadowLayer(20f, 0f, 0f, textView.context.resources.getColor(android.R.color.black))
-        }
         descriptionView?.setText(item.description)
         descriptionView?.isGone = item.description == null
-        itemView.setOnLongClickListener {
-            val dialog = Dialog(it.context)
-            dialog.setContentView(R.layout.dialog_full_image)
-
-            dialog.window?.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
-            dialog.window?.setDimAmount(0.7f) // controls dim background
-
-            val fullImageView = dialog.findViewById<ImageView>(R.id.fullImage)
-            val closeButton = dialog.findViewById<ImageView>(R.id.close_button)
-            closeButton.setOnClickListener {
-                dialog.dismiss()
-            }
-            fullImageView.setImageDrawable(imageView?.drawable)
-            fullImageView.contentDescription = textView?.text
-            fullImageView.setOnClickListener {
-                dialog.dismiss()
-            }
-
-            ViewCompat.replaceAccessibilityAction(
-                fullImageView,
-                AccessibilityNodeInfoCompat.AccessibilityActionCompat(
-                    AccessibilityNodeInfoCompat.ACTION_CLICK,
-                    "close"
-                ), "close"
-            ) { _, _ ->
-                fullImageView.performClick()
-                true
-            }
-
-            dialog.show()
-            false
-        }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/view/image_select/OutlinedTextView.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/view/image_select/OutlinedTextView.kt
@@ -1,0 +1,42 @@
+package de.westnordost.streetcomplete.view.image_select
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatTextView
+
+class OutlinedTextView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0
+) : AppCompatTextView(context, attrs, defStyle) {
+
+    private val strokePaint = Paint()
+
+    init {
+        // Copy default text paint and modify
+        strokePaint.set(paint)
+        strokePaint.style = Paint.Style.STROKE
+        strokePaint.strokeWidth = 4f  // Thickness of the outline
+        strokePaint.color = Color.BLACK  // Outline color
+        strokePaint.isAntiAlias = true
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        // Draw outline
+        val originalTextColor = currentTextColor
+
+        paint.style = Paint.Style.STROKE
+        paint.strokeWidth = 4f
+        setTextColor(Color.BLACK)
+        super.onDraw(canvas)
+
+        // Draw fill
+        paint.style = Paint.Style.FILL
+        setTextColor(originalTextColor)
+        super.onDraw(canvas)
+    }
+}
+

--- a/app/src/main/res/layout/cell_labeled_image_select.xml
+++ b/app/src/main/res/layout/cell_labeled_image_select.xml
@@ -28,7 +28,7 @@
         android:background="@drawable/image_select_cell"
         />
 
-    <TextView
+    <de.westnordost.streetcomplete.view.image_select.OutlinedTextView
         android:id="@+id/textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_full_image.xml
+++ b/app/src/main/res/layout/dialog_full_image.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/transparent"
-    android:padding="16dp">
+    android:background="@android:color/transparent">
 
     <!-- Full-screen image in a container -->
     <LinearLayout
@@ -12,13 +12,37 @@
         android:layout_gravity="center"
         android:background="@drawable/bg_image_popup"
         android:orientation="vertical"
-        android:padding="8dp">
+        android:paddingVertical="36dp">
+
+        <TextView
+            android:id="@+id/title"
+            android:textStyle="bold"
+            android:textSize="16sp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp" />
+
+        <TextView
+            android:id="@+id/description"
+            android:textSize="14sp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp" />
 
         <ImageView
             android:id="@+id/fullImage"
             android:layout_width="300dp"
             android:layout_height="400dp"
             android:scaleType="fitCenter" />
+
+        <TextView
+            android:id="@+id/choice_name"
+            android:textStyle="bold"
+            android:textAlignment="center"
+            android:textSize="18sp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp" />
     </LinearLayout>
 
     <!-- Close button on top right corner -->
@@ -29,8 +53,8 @@
         android:layout_gravity="end|top"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
-        android:focusable="true"
         android:contentDescription="@string/close_image"
+        android:focusable="true"
         android:padding="8dp"
         android:src="@drawable/ic_close_24dp" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1799,4 +1799,5 @@ Alternatively, you can leave a note (with a photo)."</string>
     <string name="change_map_layer">Change map layer</string>
     <string name="add_new_feature">Add new feature</string>
     <string name="quest_multi_select_quest">Select %1$s : %2$d %3$s selected</string>
+    <string name="quest_choice_image">quest choice image</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -116,11 +116,11 @@
 
     <style name="ImageSelectLabel">
         <item name="android:textColor">#ffffff</item>
-        <item name="android:textSize">12sp</item>
+        <item name="android:textSize">14sp</item>
         <item name="android:textStyle">bold</item>
         <item name="android:textAlignment">center</item>
         <item name="android:gravity">center_horizontal</item>
-        <item name="android:shadowRadius">20</item>
+        <item name="android:shadowRadius">2</item>
         <item name="android:shadowColor">#000000</item>
     </style>
 


### PR DESCRIPTION
This pull request introduces several updates, including changes to API endpoints for different environments, enhancements to the image selection and dialog functionality, and UI improvements. The key changes are grouped below by theme:

### API Endpoint Updates:
* Updated the URLs for the `STAGE`, `DEV`, and `PROD` environments in `WorkspaceConstants.kt` to use a new proxy (`osm-workspaces-proxy.azurewebsites.net`) instead of the previous `workspaces.sidewalks.washington.edu` domain.

### Image Selection and Dialog Enhancements:
* Added a long-press feature to the `ImageSelectAdapter` to display a full-screen dialog with additional details (title, description, choice name) and an image when an item is long-pressed. This includes updates to `LongFormAdapter`, `ImageSelectAdapter`, and `ItemViewHolder`. [[1]](diffhunk://#diff-443fe1ff07e2f69c6cdf9bffc16537edb370c667ff9b91b72749daf2da4d7542R333-R386) [[2]](diffhunk://#diff-f381c6618a52adc6ca7146cd0c44270137418374f0ebf083043cb8f1510e65b4R36-R38) [[3]](diffhunk://#diff-407adff8c349a65d70d4a460457676d896090e44bb3699966498adaead796914L50-R64)
* Introduced a new `OutlinedTextView` class to provide text with an outlined appearance for better readability on images.
* Updated the layout `dialog_full_image.xml` to include new fields for title, description, and choice name, and adjusted padding for better spacing. [[1]](diffhunk://#diff-7913a810bd3e08511f28d316988727a04201424dca58acb4e6e78a8f6344410aL15-R45) [[2]](diffhunk://#diff-7913a810bd3e08511f28d316988727a04201424dca58acb4e6e78a8f6344410aL32-R57)

### UI Improvements:
* Replaced `TextView` with the new `OutlinedTextView` in `cell_labeled_image_select.xml` for image labels.
* Adjusted the `ImageSelectLabel` style in `styles.xml`, including increasing the font size to `14sp` and reducing the shadow radius for improved clarity.

### Miscellaneous:
* Added a new string resource `quest_choice_image` in `strings.xml`.
* Minor formatting changes for better readability in `LongFormAdapter` and `ImageSelectAdapter`. [[1]](diffhunk://#diff-443fe1ff07e2f69c6cdf9bffc16537edb370c667ff9b91b72749daf2da4d7542L236-R240) [[2]](diffhunk://#diff-443fe1ff07e2f69c6cdf9bffc16537edb370c667ff9b91b72749daf2da4d7542L303-R308) [[3]](diffhunk://#diff-f381c6618a52adc6ca7146cd0c44270137418374f0ebf083043cb8f1510e65b4L20-R22)