### PR TITLE
Fix db issues

### DIFF
--- a/app/src/androidInstrumentedTest/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenDaoTest.kt
+++ b/app/src/androidInstrumentedTest/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenDaoTest.kt
@@ -22,7 +22,7 @@ class OsmQuestsHiddenDaoTest : ApplicationDbTestCase() {
     }
 
     @Test fun addGetDelete() {
-        val key = OsmQuestKey(ElementType.NODE, 123L, "bla")
+        val key = OsmQuestKey(ElementType.NODE, 123L, "bla", workspaceId)
         assertFalse(dao.delete(key))
         dao.add(key)
         assertNotNull(dao.getTimestamp(key))
@@ -32,8 +32,8 @@ class OsmQuestsHiddenDaoTest : ApplicationDbTestCase() {
 
     @Test fun getNewerThan() = runBlocking {
         val keys = listOf(
-            OsmQuestKey(ElementType.NODE, 123L, "bla"),
-            OsmQuestKey(ElementType.NODE, 124L, "bla")
+            OsmQuestKey(ElementType.NODE, 123L, "bla", workspaceId),
+            OsmQuestKey(ElementType.NODE, 124L, "bla", workspaceId)
         )
         dao.add(keys[0])
         delay(200)
@@ -45,8 +45,8 @@ class OsmQuestsHiddenDaoTest : ApplicationDbTestCase() {
 
     @Test fun getAll() {
         val keys = setOf(
-            OsmQuestKey(ElementType.NODE, 123L, "bla"),
-            OsmQuestKey(ElementType.NODE, 124L, "bla")
+            OsmQuestKey(ElementType.NODE, 123L, "bla", workspaceId),
+            OsmQuestKey(ElementType.NODE, 124L, "bla", workspaceId)
         )
         keys.forEach { dao.add(it) }
         assertEquals(
@@ -58,8 +58,8 @@ class OsmQuestsHiddenDaoTest : ApplicationDbTestCase() {
     @Test fun deleteAll() {
         assertEquals(0, dao.deleteAll())
         val keys = listOf(
-            OsmQuestKey(ElementType.NODE, 123L, "bla"),
-            OsmQuestKey(ElementType.NODE, 124L, "bla")
+            OsmQuestKey(ElementType.NODE, 123L, "bla", workspaceId),
+            OsmQuestKey(ElementType.NODE, 124L, "bla", workspaceId)
         )
         keys.forEach { dao.add(it) }
         assertEquals(2, dao.deleteAll())
@@ -69,7 +69,7 @@ class OsmQuestsHiddenDaoTest : ApplicationDbTestCase() {
 
     @Test fun countAll() {
         assertEquals(0, dao.countAll())
-        dao.add(OsmQuestKey(ElementType.NODE, 123L, "bla"))
+        dao.add(OsmQuestKey(ElementType.NODE, 123L, "bla", workspaceId))
         assertEquals(1, dao.countAll())
     }
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestAndroid.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestAndroid.kt
@@ -11,7 +11,8 @@ import de.westnordost.streetcomplete.quests.note_discussion.OsmNoteQuestType
 /** Represents one task for the user to contribute to a public OSM note */
 data class OsmNoteQuestAndroid(
     override val id: Long,
-    override val position: LatLon
+    override val position: LatLon,
+    override var workspaceId: Int
 ) : OsmNoteQuest, Quest {
     override val type: QuestType get() = OsmNoteQuestType
     override val key: OsmNoteQuestKey by lazy { OsmNoteQuestKey(id) }
@@ -19,5 +20,5 @@ data class OsmNoteQuestAndroid(
     override val geometry: ElementGeometry get() = ElementPointGeometry(position)
 }
 
-actual fun createOsmNoteQuest(id: Long, position: LatLon): OsmNoteQuest =
-    OsmNoteQuestAndroid(id, position)
+actual fun createOsmNoteQuest(id: Long, position: LatLon, workspaceId: Int): OsmNoteQuest =
+    OsmNoteQuestAndroid(id, position, workspaceId)

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
@@ -1183,7 +1183,7 @@ class MainActivity :
                 ?.takeIf { questsHiddenSource.get(OsmNoteQuestKey(it.id)) == null }
         }
         if (note != null) {
-            showQuestDetails(createOsmNoteQuest(note.id, note.position))
+            showQuestDetails(createOsmNoteQuest(note.id, note.position, note.workspaceId))
             return
         }
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainScreen.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainScreen.kt
@@ -551,6 +551,10 @@ object PreviewEditHistoryViewModel : EditHistoryViewModel() {
         TODO("Not yet implemented")
     }
 
+    override fun refreshForNewWorkspace() {
+        TODO("Not yet implemented")
+    }
+
     override val featureDictionaryLazy: Lazy<FeatureDictionary>
         get() = TODO("Not yet implemented")
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/edithistory/EditHistoryItem.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/edithistory/EditHistoryItem.kt
@@ -80,6 +80,6 @@ private fun PreviewEditsColumnItem() {
         onSelect = { selected = !selected },
         onUndo = {},
         modifier = Modifier.width(80.dp),
-        edit = OsmQuestHidden(ElementType.NODE, 1L, AddGenericLong(Elements()), ElementPointGeometry(LatLon(0.0, 0.0)), 1L),
+        edit = OsmQuestHidden(ElementType.NODE, 1L, AddGenericLong(Elements()), ElementPointGeometry(LatLon(0.0, 0.0)), 1L, 0),
     )
 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/EditHistoryPinsManager.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/EditHistoryPinsManager.kt
@@ -13,6 +13,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestHidden
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEdit
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestHidden
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.quest.OsmNoteQuestKey
 import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 import de.westnordost.streetcomplete.screens.main.edithistory.icon
@@ -29,6 +30,7 @@ import kotlinx.coroutines.withContext
 class EditHistoryPinsManager(
     private val pinsMapComponent: PinsMapComponent,
     private val editHistorySource: EditHistorySource,
+    private val preferences: Preferences
 ) : DefaultLifecycleObserver {
 
     private val viewLifecycleScope: CoroutineScope = CoroutineScope(SupervisorJob())
@@ -79,7 +81,7 @@ class EditHistoryPinsManager(
     }
 
     fun getEditKey(properties: Map<String, String>): EditKey? =
-        properties.toEditKey()
+        properties.toEditKey(preferences.workspaceId ?: 0)
 
     private fun updatePins() {
         if (!isVisible) return
@@ -136,7 +138,7 @@ private fun Edit.toProperties(): List<Pair<String, String>> = when (this) {
     else -> throw IllegalArgumentException()
 }
 
-private fun Map<String, String>.toEditKey(): EditKey? = when (get(MARKER_EDIT_TYPE)) {
+private fun Map<String, String>.toEditKey(workspaceId: Int): EditKey? = when (get(MARKER_EDIT_TYPE)) {
     EDIT_TYPE_ELEMENT ->
         ElementEditKey(getValue(MARKER_ID).toLong())
     EDIT_TYPE_NOTE ->
@@ -145,7 +147,8 @@ private fun Map<String, String>.toEditKey(): EditKey? = when (get(MARKER_EDIT_TY
         QuestHiddenKey(OsmQuestKey(
             ElementType.valueOf(getValue(MARKER_ELEMENT_TYPE)),
             getValue(MARKER_ELEMENT_ID).toLong(),
-            getValue(MARKER_QUEST_TYPE)
+            getValue(MARKER_QUEST_TYPE),
+            workspaceId
         ))
     EDIT_TYPE_HIDE_OSM_NOTE_QUEST ->
         QuestHiddenKey(OsmNoteQuestKey(getValue(MARKER_NOTE_ID).toLong()))

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -300,12 +300,13 @@ class MainMapFragment : MapFragment(), ShowsGeometryMarkers {
             questTypeRegistry,
             visibleQuestsSource,
             accessibilityOverlay,
-            this
+            this,
+            prefs
         )
         questPinsManager!!.isVisible = pinMode == PinMode.QUESTS
         viewLifecycleOwner.lifecycle.addObserver(questPinsManager!!)
 
-        editHistoryPinsManager = EditHistoryPinsManager(pinsMapComponent!!, editHistorySource)
+        editHistoryPinsManager = EditHistoryPinsManager(pinsMapComponent!!, editHistorySource, prefs)
         editHistoryPinsManager!!.isVisible = pinMode == PinMode.EDITS
         viewLifecycleOwner.lifecycle.addObserver(editHistoryPinsManager!!)
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
@@ -18,6 +18,7 @@ import de.westnordost.streetcomplete.data.download.tiles.enclosingTilesRect
 import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementType
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.quest.OsmNoteQuestKey
 import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 import de.westnordost.streetcomplete.data.quest.Quest
@@ -62,6 +63,7 @@ class QuestPinsManager(
     private val visibleQuestsSource: VisibleQuestsSource,
     private val accessibilityOverlay: FrameLayout,
     private val mapFragment: MainMapFragment,
+    private val preferences: Preferences
 ) : DefaultLifecycleObserver {
     private val overlayPositions: MutableList<Pair<Float, Float>> = mutableListOf()
 
@@ -107,6 +109,9 @@ class QuestPinsManager(
             invalidate()
         }
     }
+
+    private val workspaceId
+        get() = preferences.workspaceId ?: 0
 
     private val questTypeOrderListener = object : QuestTypeOrderSource.Listener {
         override fun onQuestTypeOrderAdded(item: QuestType, toAfter: QuestType) {
@@ -163,7 +168,7 @@ class QuestPinsManager(
     }
 
     fun getQuestKey(properties: Map<String, String>): QuestKey? =
-        properties.toQuestKey()
+        properties.toQuestKey(workspaceId)
 
     fun onNewScreenPosition(forceUpdate: Boolean = false) {
         if (!isStarted || !isVisible) return
@@ -236,6 +241,7 @@ class QuestPinsManager(
             }
             added.forEach {
                 if (displayedBBox.contains(it.position)) {
+                    it.workspaceId = workspaceId
                     questsInView[it.key] = createQuestPins(it)
                     hasChanges = true
                 } else {
@@ -426,7 +432,7 @@ private fun QuestKey.toProperties(): List<Pair<String, String>> = when (this) {
     )
 }
 
-private fun Map<String, String>.toQuestKey(): QuestKey? = when (get(MARKER_QUEST_GROUP)) {
+private fun Map<String, String>.toQuestKey(workspaceId: Int): QuestKey? = when (get(MARKER_QUEST_GROUP)) {
     QUEST_GROUP_OSM_NOTE ->
         OsmNoteQuestKey(getValue(MARKER_NOTE_ID).toLong())
 
@@ -434,7 +440,8 @@ private fun Map<String, String>.toQuestKey(): QuestKey? = when (get(MARKER_QUEST
         OsmQuestKey(
             ElementType.valueOf(getValue(MARKER_ELEMENT_TYPE)),
             getValue(MARKER_ELEMENT_ID).toLong(),
-            getValue(MARKER_QUEST_TYPE)
+            getValue(MARKER_QUEST_TYPE),
+            workspaceId
         )
 
     else -> null

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkSpaceActivity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkSpaceActivity.kt
@@ -288,6 +288,7 @@ fun AppNavigator(
             }
             WorkSpaceListScreen(
                 viewModel = koinViewModel(),
+                editHistoryViewModel = koinViewModel(),
                 modifier = modifier.padding(innerPadding)
             )
         }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkspaceListScreen.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkspaceListScreen.kt
@@ -53,12 +53,17 @@ import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.workspace.Workspace
 import de.westnordost.streetcomplete.quests.sidewalk_long_form.data.Elements
 import de.westnordost.streetcomplete.screens.main.MainActivity
+import de.westnordost.streetcomplete.screens.main.edithistory.EditHistoryViewModel
 import de.westnordost.streetcomplete.screens.user.UserActivity
 import de.westnordost.streetcomplete.ui.theme.ProximaNovaFontFamily
 import de.westnordost.streetcomplete.util.satellite_layers.Imagery
 
 @Composable
-fun WorkSpaceListScreen(viewModel: WorkspaceViewModel, modifier: Modifier = Modifier) {
+fun WorkSpaceListScreen(
+    viewModel: WorkspaceViewModel,
+    editHistoryViewModel: EditHistoryViewModel,
+    modifier: Modifier = Modifier,
+) {
     val workspaceListState by viewModel.showWorkspaces.collectAsState()
     var isLoading by remember { mutableStateOf(false) }
     var isLongFormLoading by remember { mutableStateOf(false) }
@@ -120,7 +125,6 @@ fun WorkSpaceListScreen(viewModel: WorkspaceViewModel, modifier: Modifier = Modi
                             viewModel
                         )
                     }
-
                 }
             }
 
@@ -172,6 +176,7 @@ fun WorkSpaceListScreen(viewModel: WorkspaceViewModel, modifier: Modifier = Modi
                                 longFormState.imageryList,
                                 workspace
                             )
+                            editHistoryViewModel.refreshForNewWorkspace()
                         }
 
                         is WorkspaceLongFormState.Error -> {
@@ -195,7 +200,7 @@ fun finishAndLaunchNewActivity(
     context: Context,
     addLongFormResponseItems: List<Elements>,
     imageryList: List<Imagery>?,
-    workspace: Workspace
+    workspace: Workspace,
 ) {
     val activity = context as? Activity
     activity?.let {
@@ -311,7 +316,7 @@ fun WorkSpaceListItem(
 
 @Composable
 fun CircularProgressWithText(
-    text: String
+    text: String,
 ) {
     Column(
         verticalArrangement = Arrangement.Center,

--- a/app/src/androidMain/res/layout/form_leave_note.xml
+++ b/app/src/androidMain/res/layout/form_leave_note.xml
@@ -12,13 +12,6 @@
         android:layout_height="wrap_content"
         tools:text="@string/create_new_note_description"/>
 
-    <TextView
-        android:id="@+id/hintLabel"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/create_new_note_hint"
-        />
-
     <EditText
         android:id="@+id/noteInput"
         android:layout_width="match_parent"
@@ -27,14 +20,8 @@
         android:gravity="top|start"
         android:layout_marginTop="8dp"
         android:minLines="3"
+        android:layout_marginBottom="64dp"
         android:background="@drawable/background_edittext_outline"
         />
-
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/attachPhotoFragment"
-        android:name="de.westnordost.streetcomplete.quests.note_discussion.AttachPhotoFragment"
-        android:layout_marginTop="8dp"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
 
 </LinearLayout>

--- a/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/testutils/TestDataShortcuts2.kt
+++ b/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/testutils/TestDataShortcuts2.kt
@@ -42,6 +42,6 @@ fun osmQuestKey(
     elementType: ElementType = ElementType.NODE,
     elementId: Long = 1L,
     questTypeName: String = QUEST_TYPE.name
-) = OsmQuestKey(elementType, elementId, questTypeName)
+) = OsmQuestKey(elementType, elementId, questTypeName, workspaceId)
 
 val QUEST_TYPE = TestQuestTypeA()

--- a/app/src/appleMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuest.apple.kt
+++ b/app/src/appleMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuest.apple.kt
@@ -1,0 +1,9 @@
+package de.westnordost.streetcomplete.data.osmnotes.notequests
+
+actual fun createOsmNoteQuest(
+    id: Long,
+    position: de.westnordost.streetcomplete.data.osm.mapdata.LatLon,
+    workspaceId: Int,
+): OsmNoteQuest {
+    TODO("Not yet implemented")
+}

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/DatabaseInitializer.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/DatabaseInitializer.kt
@@ -30,7 +30,7 @@ import de.westnordost.streetcomplete.util.logs.Log
 
 /** Creates the database and upgrades it */
 object DatabaseInitializer {
-    const val DB_VERSION = 20
+    const val DB_VERSION = 21
 
     fun onCreate(db: Database) {
         // OSM notes
@@ -279,6 +279,12 @@ object DatabaseInitializer {
             db.exec("ALTER TABLE osm_quests ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
             db.exec("ALTER TABLE osm_quests_hidden ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
             db.exec("ALTER TABLE osm_edit_elements ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
+        }
+
+        if (oldVersion<= 20 && newVersion == 21){
+            db.exec("ALTER TABLE osm_notes ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
+            db.exec("ALTER TABLE osm_note_edits ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
+            db.exec("ALTER TABLE osm_quests_hidden ADD COLUMN workspace_id INTEGER DEFAULT 0 NOT NULL")
         }
     }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/edithistory/Edit.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/edithistory/Edit.kt
@@ -10,6 +10,7 @@ interface Edit {
     val isUndoable: Boolean
     val position: LatLon
     val isSynced: Boolean?
+    val workspaceId : Int
 }
 
 @Serializable

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/edithistory/EditHistoryController.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/edithistory/EditHistoryController.kt
@@ -13,6 +13,7 @@ import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsController
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsSource
 import de.westnordost.streetcomplete.data.osmnotes.edits.NotesWithEditsSource
 import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestHidden
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.quest.OsmNoteQuestKey
 import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 import de.westnordost.streetcomplete.data.quest.QuestKey
@@ -30,9 +31,11 @@ class EditHistoryController(
     private val notesSource: NotesWithEditsSource,
     private val mapDataSource: MapDataWithEditsSource,
     private val questTypeRegistry: QuestTypeRegistry,
+    private val preferences: Preferences
 ) : EditHistorySource {
     private val listeners = Listeners<EditHistorySource.Listener>()
-
+    private val workspaceId
+        get() = preferences.workspaceId ?: 0
     private val osmElementEditsListener = object : ElementEditsSource.Listener {
         override fun onAddedEdit(edit: ElementEdit) {
             if (edit.action !is IsRevertAction) onAdded(edit)
@@ -72,7 +75,7 @@ class EditHistoryController(
             is OsmQuestKey -> {
                 val geometry = mapDataSource.getGeometry(key.elementType, key.elementId) ?: return null
                 val questType = questTypeRegistry.getByName(key.questTypeName) as? OsmElementQuestType<*> ?: return null
-                OsmQuestHidden(key.elementType, key.elementId, questType, geometry, timestamp)
+                OsmQuestHidden(key.elementType, key.elementId, questType, geometry, timestamp, workspaceId)
             }
         }
     }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/edithistory/EditHistoryController.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/edithistory/EditHistoryController.kt
@@ -98,6 +98,10 @@ class EditHistoryController(
         }
     }
 
+    public fun refresh(){
+        hiddenQuestsController.refreshCache()
+    }
+
     fun deleteSyncedOlderThan(timestamp: Long): Int =
         elementEditsController.deleteSyncedOlderThan(timestamp) +
         noteEditsController.deleteSyncedOlderThan(timestamp)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/edithistory/EditHistoryModule.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/edithistory/EditHistoryModule.kt
@@ -4,5 +4,5 @@ import org.koin.dsl.module
 
 val editHistoryModule = module {
     single<EditHistorySource> { get<EditHistoryController>() }
-    single { EditHistoryController(get(), get(), get(), get(), get(), get()) }
+    factory { EditHistoryController(get(), get(), get(), get(), get(), get(), get()) }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/ElementEdit.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/ElementEdit.kt
@@ -30,7 +30,8 @@ data class ElementEdit(
     val action: ElementEditAction,
 
     /** Whether the user was near the element that is being edited when this edit was created */
-    val isNearUserLocation: Boolean
+    val isNearUserLocation: Boolean,
+    override var workspaceId: Int
 ) : Edit {
     override val isUndoable: Boolean get() = !isSynced || action is IsActionRevertable
     override val key: ElementEditKey get() = ElementEditKey(id)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/ElementEditsController.kt
@@ -18,7 +18,8 @@ class ElementEditsController(
 ) : ElementEditsSource, AddElementEditsController {
     /* Must be a singleton because there is a listener that should respond to a change in the
      * database table */
-
+    private val workspaceId
+        get() = prefs.workspaceId ?: 0
     private val listeners = Listeners<ElementEditsSource.Listener>()
 
     private val lock = ReentrantLock()
@@ -34,7 +35,7 @@ class ElementEditsController(
         isNearUserLocation: Boolean
     ) {
         Log.d(TAG, "Add ${type.name} for ${action.elementKeys.joinToString()}")
-        add(ElementEdit(0, type, geometry, source, nowAsEpochMilliseconds(), false, action, isNearUserLocation))
+        add(ElementEdit(0, type, geometry, source, nowAsEpochMilliseconds(), false, action, isNearUserLocation, workspaceId))
     }
 
     override fun get(id: Long): ElementEdit? =
@@ -121,7 +122,7 @@ class ElementEditsController(
             // need to delete the original edit from history because this should not be undoable anymore
             delete(edit)
             // ... and add a new revert to the queue
-            add(ElementEdit(0, edit.type, edit.originalGeometry, edit.source, nowAsEpochMilliseconds(), false, reverted, edit.isNearUserLocation))
+            add(ElementEdit(0, edit.type, edit.originalGeometry, edit.source, nowAsEpochMilliseconds(), false, reverted, edit.isNearUserLocation, workspaceId))
         } else {
             // not uploaded yet
             Log.d(TAG, "Undo ${edit.type.name} for ${edit.action.elementKeys.joinToString()}")

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDao.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/ElementEditsDao.kt
@@ -55,7 +55,11 @@ class ElementEditsDao(
         }
     }
 
+    private val workspaceId
+        get() = preferences.workspaceId ?: 0
+
     fun put(edit: ElementEdit) {
+        edit.workspaceId = workspaceId
         val rowId = db.replace(NAME, edit.toPairs())
         // only set id if it was "undefined" before
         if (edit.id <= 0) edit.id = rowId
@@ -119,5 +123,6 @@ class ElementEditsDao(
         getInt(IS_SYNCED) == 1,
         json.decodeFromString(getString(ACTION)),
         getInt(IS_NEAR_USER_LOCATION) == 1,
+        getInt(WORKSPACE_ID)
     )
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuest.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuest.kt
@@ -14,10 +14,16 @@ data class OsmQuest(
     override val type: OsmElementQuestType<*>,
     override val elementType: ElementType,
     override val elementId: Long,
-    override val geometry: ElementGeometry
+    override val geometry: ElementGeometry,
+    override var workspaceId : Int = 0
 ) : Quest, OsmQuestDaoEntry {
 
-    override val key: OsmQuestKey by lazy { OsmQuestKey(elementType, elementId, questTypeName) }
+    override val key: OsmQuestKey by lazy { OsmQuestKey(
+        elementType,
+        elementId,
+        questTypeName,
+        workspaceId
+    ) }
 
     override val questTypeName: String get() = type.name
 
@@ -48,7 +54,6 @@ data class OsmQuest(
         listOf(position)
     }
 
-    override var workspaceId : Int = 0
 }
 
 const val MAXIMUM_MARKER_DISTANCE = 400

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestController.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestController.kt
@@ -13,6 +13,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MutableMapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.key
 import de.westnordost.streetcomplete.data.osmnotes.Note
 import de.westnordost.streetcomplete.data.osmnotes.edits.NotesWithEditsSource
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.util.Listeners
@@ -45,8 +46,10 @@ class OsmQuestController internal constructor(
     private val notesSource: NotesWithEditsSource,
     private val questTypeRegistry: QuestTypeRegistry,
     private val countryBoundaries: Lazy<CountryBoundaries>,
+    private val preferences: Preferences
 ) : OsmQuestSource {
-
+    private val workspaceId
+        get() = preferences.workspaceId ?: 0
     private val listeners = Listeners<OsmQuestSource.Listener>()
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -167,7 +170,7 @@ class OsmQuestController internal constructor(
                         val geometry = mapDataWithGeometry.getGeometry(element.type, element.id)
                             ?: continue
                         if (!mayCreateQuest(questType, geometry, bbox)) continue
-                        questsForType.add(OsmQuest(questType, element.type, element.id, geometry))
+                        questsForType.add(OsmQuest(questType, element.type, element.id, geometry, workspaceId))
                         questCount++
                     }
 
@@ -287,7 +290,7 @@ class OsmQuestController internal constructor(
     private fun createOsmQuest(entry: OsmQuestDaoEntry, geometry: ElementGeometry?): OsmQuest? {
         if (geometry == null) return null
         val questType = questTypeRegistry.getByName(entry.questTypeName) as? OsmElementQuestType<*> ?: return null
-        return OsmQuest(questType, entry.elementType, entry.elementId, geometry)
+        return OsmQuest(questType, entry.elementType, entry.elementId, geometry, workspaceId)
     }
 
     private fun getBlacklistedPositions(bbox: BoundingBox): Set<LatLon> =

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDao.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDao.kt
@@ -24,6 +24,7 @@ class OsmQuestDao(private val db: Database, val preferences: Preferences) {
         get() = preferences.workspaceId ?: 0
 
     fun put(quest: OsmQuestDaoEntry) {
+        quest.workspaceId = workspaceId
         db.replace(NAME, quest.toPairs())
     }
 
@@ -123,5 +124,5 @@ data class BasicOsmQuestDaoEntry(
     override val elementId: Long,
     override val questTypeName: String,
     override val position: LatLon,
-    override val workspaceId: Int
+    override var workspaceId: Int
 ) : OsmQuestDaoEntry

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDaoEntry.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestDaoEntry.kt
@@ -9,8 +9,8 @@ interface OsmQuestDaoEntry {
     val elementType: ElementType
     val elementId: Long
     val position: LatLon
-    val workspaceId : Int
+    var workspaceId : Int
 }
 
 val OsmQuestDaoEntry.key get() =
-    OsmQuestKey(elementType, elementId, questTypeName)
+    OsmQuestKey(elementType, elementId, questTypeName, workspaceId)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestHidden.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestHidden.kt
@@ -12,10 +12,11 @@ data class OsmQuestHidden(
     val elementId: Long,
     val questType: OsmElementQuestType<*>,
     val geometry: ElementGeometry,
-    override val createdTimestamp: Long
+    override val createdTimestamp: Long,
+    override val workspaceId: Int
 ) : Edit {
     override val position: LatLon get() = geometry.center
-    val questKey get() = OsmQuestKey(elementType, elementId, questType.name)
+    val questKey get() = OsmQuestKey(elementType, elementId, questType.name, workspaceId)
     override val key: QuestHiddenKey get() = QuestHiddenKey(questKey)
     override val isUndoable: Boolean get() = true
     override val isSynced: Boolean? get() = null

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestModule.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestModule.kt
@@ -5,8 +5,15 @@ import org.koin.dsl.module
 
 val osmQuestModule = module {
     factory { OsmQuestDao(get(), get()) }
-    factory { OsmQuestsHiddenDao(get()) }
+    factory { OsmQuestsHiddenDao(get(), get()) }
 
     single<OsmQuestSource> { get<OsmQuestController>() }
-    single { OsmQuestController(get(), get(), get(), get(), get(named("CountryBoundariesLazy"))) }
+    single {
+        OsmQuestController(
+            get(), get(), get(),
+            get(),
+            get(named("CountryBoundariesLazy")),
+            get()
+        )
+    }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenDao.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenDao.kt
@@ -7,61 +7,71 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestsHiddenTable.Col
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestsHiddenTable.Columns.ELEMENT_TYPE
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestsHiddenTable.Columns.QUEST_TYPE
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestsHiddenTable.Columns.TIMESTAMP
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestsHiddenTable.Columns.WORKSPACE_ID
 import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestsHiddenTable.NAME
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 
 /** Persists which osm quests should be hidden (because the user selected so) */
-class OsmQuestsHiddenDao(private val db: Database) {
+class OsmQuestsHiddenDao(private val db: Database, val preferences: Preferences) {
+
+    private val workspaceId
+        get() = preferences.workspaceId ?: 0
 
     fun add(osmQuestKey: OsmQuestKey) {
+        osmQuestKey.workspaceId = workspaceId
         db.insert(NAME, osmQuestKey.toPairs())
     }
 
     fun getTimestamp(osmQuestKey: OsmQuestKey): Long? =
         db.queryOne(NAME,
-            where = "$QUEST_TYPE = ? AND $ELEMENT_ID = ? AND $ELEMENT_TYPE = ?",
+            where = "$QUEST_TYPE = ? AND $ELEMENT_ID = ? AND $ELEMENT_TYPE = ? AND $WORKSPACE_ID = ?",
             args = arrayOf(
                 osmQuestKey.questTypeName,
                 osmQuestKey.elementId,
                 osmQuestKey.elementType.name,
+                workspaceId
             )
         ) { it.getLong(TIMESTAMP) }
 
     fun delete(osmQuestKey: OsmQuestKey): Boolean =
         db.delete(NAME,
-            where = "$QUEST_TYPE = ? AND $ELEMENT_ID = ? AND $ELEMENT_TYPE = ?",
+            where = "$QUEST_TYPE = ? AND $ELEMENT_ID = ? AND $ELEMENT_TYPE = ? AND $WORKSPACE_ID = ?",
             args = arrayOf(
                 osmQuestKey.questTypeName,
                 osmQuestKey.elementId,
                 osmQuestKey.elementType.name,
+                workspaceId
             )
         ) == 1
 
     fun getNewerThan(timestamp: Long): List<OsmQuestHiddenAt> =
-        db.query(NAME, where = "$TIMESTAMP > $timestamp") { it.toOsmQuestHiddenAt() }
+        db.query(NAME, where = "$TIMESTAMP > $timestamp AND $WORKSPACE_ID = $workspaceId") { it.toOsmQuestHiddenAt() }
 
     fun getAll(): List<OsmQuestHiddenAt> =
-        db.query(NAME) { it.toOsmQuestHiddenAt() }
+        db.query(NAME, where = "$WORKSPACE_ID = $workspaceId") { it.toOsmQuestHiddenAt() }
 
     fun deleteAll(): Int =
-        db.delete(NAME)
+        db.delete(NAME, where = "$WORKSPACE_ID = $workspaceId")
 
     fun countAll(): Int =
-        db.queryOne(NAME, columns = arrayOf("COUNT(*)")) { it.getInt("COUNT(*)") } ?: 0
+        db.queryOne(NAME, columns = arrayOf("COUNT(*)"), where = "$WORKSPACE_ID = $workspaceId") { it.getInt("COUNT(*)") } ?: 0
 }
 
 private fun OsmQuestKey.toPairs() = listOf(
     ELEMENT_TYPE to elementType.name,
     ELEMENT_ID to elementId,
     QUEST_TYPE to questTypeName,
-    TIMESTAMP to nowAsEpochMilliseconds()
+    TIMESTAMP to nowAsEpochMilliseconds(),
+    WORKSPACE_ID to workspaceId
 )
 
 private fun CursorPosition.toOsmQuestKey() = OsmQuestKey(
     ElementType.valueOf(getString(ELEMENT_TYPE)),
     getLong(ELEMENT_ID),
-    getString(QUEST_TYPE)
+    getString(QUEST_TYPE),
+    getInt(WORKSPACE_ID)
 )
 
 private fun CursorPosition.toOsmQuestHiddenAt() = OsmQuestHiddenAt(

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenTable.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestsHiddenTable.kt
@@ -8,6 +8,7 @@ object OsmQuestsHiddenTable {
         const val ELEMENT_ID = "element_id"
         const val ELEMENT_TYPE = "element_type"
         const val TIMESTAMP = "timestamp"
+        const val WORKSPACE_ID = "workspace_id"
     }
 
     const val CREATE = """
@@ -16,6 +17,7 @@ object OsmQuestsHiddenTable {
             ${Columns.ELEMENT_ID} int NOT NULL,
             ${Columns.ELEMENT_TYPE} varchar(255) NOT NULL,
             ${Columns.TIMESTAMP} int NOT NULL,
+            ${Columns.WORKSPACE_ID} int NOT NULL,
             CONSTRAINT same_osm_quest PRIMARY KEY (
                 ${Columns.QUEST_TYPE},
                 ${Columns.ELEMENT_ID},

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/Note.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/Note.kt
@@ -12,6 +12,7 @@ data class Note(
     val timestampClosed: Long?,
     val status: Status,
     val comments: List<NoteComment>,
+    var workspaceId : Int
 ) {
     val isOpen get() = status == Status.OPEN
     val isClosed get() = status == Status.CLOSED

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/NoteDao.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/NoteDao.kt
@@ -4,6 +4,10 @@ import de.westnordost.streetcomplete.data.CursorPosition
 import de.westnordost.streetcomplete.data.Database
 import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestsHiddenTable
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestsHiddenTable.Columns.ELEMENT_ID
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestsHiddenTable.Columns.ELEMENT_TYPE
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestsHiddenTable.Columns.QUEST_TYPE
 import de.westnordost.streetcomplete.data.osmnotes.NoteTable.Columns.CLOSED
 import de.westnordost.streetcomplete.data.osmnotes.NoteTable.Columns.COMMENTS
 import de.westnordost.streetcomplete.data.osmnotes.NoteTable.Columns.CREATED
@@ -12,28 +16,35 @@ import de.westnordost.streetcomplete.data.osmnotes.NoteTable.Columns.LAST_SYNC
 import de.westnordost.streetcomplete.data.osmnotes.NoteTable.Columns.LATITUDE
 import de.westnordost.streetcomplete.data.osmnotes.NoteTable.Columns.LONGITUDE
 import de.westnordost.streetcomplete.data.osmnotes.NoteTable.Columns.STATUS
+import de.westnordost.streetcomplete.data.osmnotes.NoteTable.Columns.WORKSPACE_ID
 import de.westnordost.streetcomplete.data.osmnotes.NoteTable.NAME
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 /** Stores OSM notes */
-class NoteDao(private val db: Database) {
+class NoteDao(private val db: Database, val preferences: Preferences) {
+
+    private val workspaceId
+        get() = preferences.workspaceId ?: 0
+
     fun put(note: Note) {
+        note.workspaceId = workspaceId
         db.replace(NAME, note.toPairs())
     }
 
     fun get(id: Long): Note? =
-        db.queryOne(NAME, where = "$ID = $id") { it.toNote() }
+        db.queryOne(NAME, where = "$ID = $id AND $WORKSPACE_ID = $workspaceId") { it.toNote() }
 
     fun delete(id: Long): Boolean =
-        db.delete(NAME, "$ID = $id") == 1
+        db.delete(NAME, "$ID = $id AND $WORKSPACE_ID = $workspaceId") == 1
 
     fun putAll(notes: Collection<Note>) {
         if (notes.isEmpty()) return
 
         db.replaceMany(NAME,
-            arrayOf(ID, LATITUDE, LONGITUDE, STATUS, CREATED, CLOSED, COMMENTS, LAST_SYNC),
+            arrayOf(ID, LATITUDE, LONGITUDE, STATUS, CREATED, CLOSED, COMMENTS, LAST_SYNC, WORKSPACE_ID),
             notes.map { arrayOf(
                 it.id,
                 it.position.latitude,
@@ -42,7 +53,8 @@ class NoteDao(private val db: Database) {
                 it.timestampCreated,
                 it.timestampClosed,
                 Json.encodeToString(it.comments),
-                nowAsEpochMilliseconds()
+                nowAsEpochMilliseconds(),
+                workspaceId
             ) }
         )
     }
@@ -58,7 +70,7 @@ class NoteDao(private val db: Database) {
 
     fun getAll(ids: Collection<Long>): List<Note> {
         if (ids.isEmpty()) return emptyList()
-        return db.query(NAME, where = "$ID IN (${ids.joinToString(",")})") { it.toNote() }
+        return db.query(NAME, where = "$ID IN (${ids.joinToString(",")}) AND $WORKSPACE_ID = $workspaceId") { it.toNote() }
     }
 
     fun getIdsOlderThan(timestamp: Long, limit: Int? = null): List<Long> =
@@ -67,18 +79,21 @@ class NoteDao(private val db: Database) {
         } else {
             db.query(NAME,
                 columns = arrayOf(ID),
-                where = "$LAST_SYNC < $timestamp",
+                where = "$LAST_SYNC < $timestamp AND $WORKSPACE_ID = $workspaceId",
                 limit = limit
             ) { it.getLong(ID) }
         }
 
     fun deleteAll(ids: Collection<Long>): Int {
         if (ids.isEmpty()) return 0
-        return db.delete(NAME, "$ID IN (${ids.joinToString(",")})")
+        return db.delete(NAME, "$ID IN (${ids.joinToString(",")}) AND $WORKSPACE_ID = $workspaceId")
     }
 
     fun clear() {
-        db.delete(NAME)
+        db.delete(NAME,  where = "$WORKSPACE_ID = ?",
+            args = arrayOf(
+                workspaceId
+            ))
     }
 
     private fun Note.toPairs() = listOf(
@@ -89,7 +104,8 @@ class NoteDao(private val db: Database) {
         CREATED to timestampCreated,
         CLOSED to timestampClosed,
         COMMENTS to Json.encodeToString(comments),
-        LAST_SYNC to nowAsEpochMilliseconds()
+        LAST_SYNC to nowAsEpochMilliseconds(),
+        WORKSPACE_ID to workspaceId
     )
 
     private fun CursorPosition.toNote() = Note(
@@ -98,11 +114,13 @@ class NoteDao(private val db: Database) {
         getLong(CREATED),
         getLongOrNull(CLOSED),
         Note.Status.valueOf(getString(STATUS)),
-        Json.decodeFromString(getString(COMMENTS))
+        Json.decodeFromString(getString(COMMENTS)),
+        getInt(WORKSPACE_ID)
     )
 
     private fun inBoundsSql(bbox: BoundingBox): String = """
         ($LATITUDE BETWEEN ${bbox.min.latitude} AND ${bbox.max.latitude}) AND
-        ($LONGITUDE BETWEEN ${bbox.min.longitude} AND ${bbox.max.longitude})
+        ($LONGITUDE BETWEEN ${bbox.min.longitude} AND ${bbox.max.longitude}) AND
+        ($WORKSPACE_ID = $workspaceId)
     """.trimIndent()
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/NoteTable.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/NoteTable.kt
@@ -12,6 +12,7 @@ object NoteTable {
         const val CLOSED = "note_closed"
         const val COMMENTS = "comments"
         const val LAST_SYNC = "last_sync"
+        const val WORKSPACE_ID = "workspace_id"
     }
 
     const val CREATE = """
@@ -23,7 +24,8 @@ object NoteTable {
             ${Columns.CLOSED} int,
             ${Columns.STATUS} varchar(255) NOT NULL,
             ${Columns.COMMENTS} text NOT NULL,
-            ${Columns.LAST_SYNC} int NOT NULL
+            ${Columns.LAST_SYNC} int NOT NULL,
+            ${Columns.WORKSPACE_ID} int NOT NULL
         );
     """
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/NotesApiClient.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/NotesApiClient.kt
@@ -16,6 +16,7 @@ import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.expectSuccess
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.statement.bodyAsChannel
@@ -47,13 +48,14 @@ class NotesApiClient(
     suspend fun create(pos: LatLon, text: String): Note = wrapApiClientExceptions {
         val response = httpClient.post(workspaceConfigProvider.osmBaseUrl + "notes") {
             userAccessTokenSource.accessToken?.let { bearerAuth(it) }
+            header("X-Workspace", workspaceConfigProvider.workspaceId.toString())
             parameter("lat", pos.latitude.format(7))
             parameter("lon", pos.longitude.format(7))
             parameter("text", text)
             expectSuccess = true
         }
         val source = response.bodyAsChannel().asSource().buffered()
-        return notesApiParser.parseNotes(source).single()
+        return notesApiParser.parseNotes(source, workspaceConfigProvider.workspaceId).single()
     }
 
     /**
@@ -75,7 +77,7 @@ class NotesApiClient(
                 expectSuccess = true
             }
             val source = response.bodyAsChannel().asSource().buffered()
-            return notesApiParser.parseNotes(source).single()
+            return notesApiParser.parseNotes(source, workspaceConfigProvider.workspaceId).single()
         } catch (e: ClientRequestException) {
             when (e.response.status) {
                 // hidden by moderator, does not exist (yet), has already been closed
@@ -96,9 +98,11 @@ class NotesApiClient(
      */
     suspend fun get(id: Long): Note? = wrapApiClientExceptions {
         try {
-            val response = httpClient.get(workspaceConfigProvider.osmBaseUrl + "notes/$id") { expectSuccess = true }
+            val response = httpClient.get(workspaceConfigProvider.osmBaseUrl + "notes/$id") { expectSuccess = true
+                header("X-Workspace", workspaceConfigProvider.workspaceId.toString())
+            }
             val source = response.bodyAsChannel().asSource().buffered()
-            return notesApiParser.parseNotes(source).singleOrNull()
+            return notesApiParser.parseNotes(source, workspaceConfigProvider.workspaceId).singleOrNull()
         } catch (e: ClientRequestException) {
             when (e.response.status) {
                 // hidden by moderator, does not exist (yet)
@@ -128,6 +132,8 @@ class NotesApiClient(
 
         try {
             val response = httpClient.get(workspaceConfigProvider.osmBaseUrl + "notes") {
+                header("X-Workspace", workspaceConfigProvider.workspaceId.toString())
+
                 userAccessTokenSource.accessToken?.let { bearerAuth(it) }
                 parameter("bbox", bounds.toOsmApiString())
                 parameter("limit", limit)
@@ -135,7 +141,7 @@ class NotesApiClient(
                 expectSuccess = true
             }
             val source = response.bodyAsChannel().asSource().buffered()
-            return notesApiParser.parseNotes(source)
+            return notesApiParser.parseNotes(source, workspaceConfigProvider.workspaceId)
         } catch (e: ClientRequestException) {
             if (e.response.status == HttpStatusCode.BadRequest) {
                 throw QueryTooBigException(e.message, e)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/NotesApiParser.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/NotesApiParser.kt
@@ -13,13 +13,14 @@ import nl.adaptivity.xmlutil.EventType.*
 import nl.adaptivity.xmlutil.XmlReader
 import nl.adaptivity.xmlutil.core.kxio.newReader
 import nl.adaptivity.xmlutil.xmlStreaming
+import kotlin.time.ExperimentalTime
 
 class NotesApiParser {
-    fun parseNotes(source: Source): List<Note> =
-        xmlStreaming.newReader(source).parseNotes()
+    fun parseNotes(source: Source, workspaceId: Int?): List<Note> =
+        xmlStreaming.newReader(source).parseNotes(workspaceId)
 }
 
-private fun XmlReader.parseNotes(): List<Note> = try {
+private fun XmlReader.parseNotes(workspaceId: Int?): List<Note> = try {
     val result = ArrayList<Note>()
 
     var note: ApiNote? = null
@@ -55,7 +56,7 @@ private fun XmlReader.parseNotes(): List<Note> = try {
             // note
             "note" -> {
                 val n = note!!
-                result.add(Note(n.position, n.id!!, n.timestampCreated!!, n.timestampClosed, n.status!!, n.comments))
+                result.add(Note(n.position, n.id!!, n.timestampCreated!!, n.timestampClosed, n.status!!, n.comments, workspaceId ?: 0))
             }
             // comment
             "comment" -> {
@@ -94,5 +95,6 @@ private val dateFormat = DateTimeComponents.Format {
     timeZoneId()
 }
 
+@OptIn(ExperimentalTime::class)
 private fun parseTimestamp(date: String): Long =
     dateFormat.parse(date).toInstantUsingOffset().toEpochMilliseconds()

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/NotesModule.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/NotesModule.kt
@@ -7,7 +7,7 @@ import org.koin.dsl.module
 val notesModule = module {
     factory { AvatarsDownloader(get(), get(), get(), get(named("AvatarsCacheDirectory"))) }
     factory { AvatarsInNotesUpdater(get()) }
-    factory { NoteDao(get()) }
+    factory { NoteDao(get(), get()) }
     factory { NotesDownloader(get(), get()) }
     factory { PhotoServiceApiClient(get(), get(), ApplicationConstants.SC_PHOTO_SERVICE_URL) }
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEdit.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEdit.kt
@@ -37,6 +37,7 @@ data class NoteEdit(
 
     /** attached GPS location history */
     val track: List<Trackpoint>,
+    override var workspaceId: Int
 ) : Edit {
     override val isUndoable: Boolean get() = !isSynced
     override val key: NoteEditKey get() = NoteEditKey(id)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsController.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsController.kt
@@ -5,17 +5,20 @@ import de.westnordost.streetcomplete.data.osm.mapdata.ElementIdUpdate
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osmnotes.Note
 import de.westnordost.streetcomplete.data.osmtracks.Trackpoint
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 import kotlinx.atomicfu.locks.ReentrantLock
 import kotlinx.atomicfu.locks.withLock
 
 class NoteEditsController(
-    private val editsDB: NoteEditsDao
+    private val editsDB: NoteEditsDao,
+    private val preferences: Preferences
 ) : NoteEditsSource {
     /* Must be a singleton because there is a listener that should respond to a change in the
      * database table */
-
+    private val workspaceId
+        get() = preferences.workspaceId ?: 0
     private val listeners = Listeners<NoteEditsSource.Listener>()
 
     private val lock = ReentrantLock()
@@ -38,7 +41,7 @@ class NoteEditsController(
             nowAsEpochMilliseconds(),
             false,
             imagePaths.isNotEmpty(),
-            track,
+            track, workspaceId
         )
         lock.withLock { editsDB.add(edit) }
         onAddedEdit(edit)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsDao.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsDao.kt
@@ -15,109 +15,117 @@ import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsTable.Columns.
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsTable.Columns.TEXT
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsTable.Columns.TRACK
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsTable.Columns.TYPE
+import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsTable.Columns.WORKSPACE_ID
 import de.westnordost.streetcomplete.data.osmnotes.edits.NoteEditsTable.NAME
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-class NoteEditsDao(private val db: Database) {
+class NoteEditsDao(private val db: Database, private val preferences: Preferences) {
+
+    private val workspaceId
+        get() = preferences.workspaceId ?: 0
+
     fun add(edit: NoteEdit): Boolean =
         db.transaction {
+            edit.workspaceId = workspaceId
             val rowId = db.insert(NAME, edit.toPairs())
             if (rowId == -1L) return@transaction false
             edit.id = rowId
             // if the note id is not set, set it to the negative of the row id
             if (edit.noteId == 0L) {
-                db.update(NAME, listOf(NOTE_ID to -rowId), "$ID = $rowId")
+                db.update(NAME, listOf(NOTE_ID to -rowId), "$ID = $rowId AND $WORKSPACE_ID = $workspaceId")
                 edit.noteId = -rowId
             }
             return@transaction true
         }
 
     fun get(id: Long): NoteEdit? =
-        db.queryOne(NAME, where = "$ID = $id") { it.toNoteEdit() }
+        db.queryOne(NAME, where = "$ID = $id AND $WORKSPACE_ID = $workspaceId") { it.toNoteEdit() }
 
     fun getAll(): List<NoteEdit> =
-        db.query(NAME, orderBy = "$IS_SYNCED, $CREATED_TIMESTAMP") { it.toNoteEdit() }
+        db.query(NAME,where = "$WORKSPACE_ID = $workspaceId", orderBy = "$IS_SYNCED, $CREATED_TIMESTAMP") { it.toNoteEdit() }
 
     fun getOldestUnsynced(): NoteEdit? =
         db.queryOne(NAME,
-            where = "$IS_SYNCED = 0",
+            where = "$IS_SYNCED = 0 AND $WORKSPACE_ID = $workspaceId",
             orderBy = CREATED_TIMESTAMP
         ) { it.toNoteEdit() }
 
     fun getUnsyncedCount(): Int =
         db.queryOne(NAME,
             columns = arrayOf("COUNT(*) as count"),
-            where = "$IS_SYNCED = 0"
+            where = "$IS_SYNCED = 0 AND $WORKSPACE_ID = $workspaceId"
         ) { it.getInt("count") } ?: 0
 
     fun getAllUnsynced(): List<NoteEdit> =
         db.query(NAME,
-            where = "$IS_SYNCED = 0",
+            where = "$IS_SYNCED = 0 AND $WORKSPACE_ID = $workspaceId",
             orderBy = CREATED_TIMESTAMP
         ) { it.toNoteEdit() }
 
     fun getAllUnsyncedForNote(noteId: Long): List<NoteEdit> =
         db.query(NAME,
-            where = "$NOTE_ID = $noteId AND $IS_SYNCED = 0",
+            where = "$NOTE_ID = $noteId AND $WORKSPACE_ID = $workspaceId AND $IS_SYNCED = 0",
             orderBy = CREATED_TIMESTAMP
         ) { it.toNoteEdit() }
 
     fun getAllUnsyncedForNotes(noteIds: Collection<Long>): List<NoteEdit> {
         val notes = noteIds.joinToString(",")
         return db.query(NAME,
-            where = "$NOTE_ID IN ($notes) AND $IS_SYNCED = 0",
+            where = "$NOTE_ID IN ($notes) AND $WORKSPACE_ID = $workspaceId AND $IS_SYNCED = 0",
             orderBy = CREATED_TIMESTAMP
         ) { it.toNoteEdit() }
     }
 
     fun getAllUnsynced(bbox: BoundingBox): List<NoteEdit> =
         db.query(NAME,
-            where = "$IS_SYNCED = 0 AND " + inBoundsSql(bbox),
+            where = "$IS_SYNCED = 0 AND $WORKSPACE_ID = $workspaceId AND " + inBoundsSql(bbox),
             orderBy = CREATED_TIMESTAMP
         ) { it.toNoteEdit() }
 
     fun getAllUnsyncedPositions(bbox: BoundingBox): List<LatLon> =
         db.query(NAME,
             columns = arrayOf(LATITUDE, LONGITUDE),
-            where = "$IS_SYNCED = 0 AND " + inBoundsSql(bbox),
+            where = "$IS_SYNCED = 0 AND $WORKSPACE_ID = $workspaceId AND " + inBoundsSql(bbox),
             orderBy = CREATED_TIMESTAMP
         ) { LatLon(it.getDouble(LATITUDE), it.getDouble(LONGITUDE)) }
 
     fun markSynced(id: Long): Boolean =
-        db.update(NAME, listOf(IS_SYNCED to 1), "$ID = $id", null) == 1
+        db.update(NAME, listOf(IS_SYNCED to 1), "$ID = $id AND $WORKSPACE_ID = $workspaceId", null) == 1
 
     fun delete(id: Long): Boolean =
-        db.delete(NAME, "$ID = $id") == 1
+        db.delete(NAME, "$ID = $id AND $WORKSPACE_ID = $workspaceId") == 1
 
     fun deleteAll(ids: List<Long>): Int {
         if (ids.isEmpty()) return 0
-        return db.delete(NAME, "$ID IN (${ids.joinToString(",")})")
+        return db.delete(NAME, "$ID IN (${ids.joinToString(",")}) AND $WORKSPACE_ID = $workspaceId")
     }
 
     fun getSyncedOlderThan(timestamp: Long): List<NoteEdit> =
-        db.query(NAME, where = "$IS_SYNCED = 1 AND $IMAGES_NEED_ACTIVATION = 0 AND $CREATED_TIMESTAMP < $timestamp") { it.toNoteEdit() }
+        db.query(NAME, where = "$IS_SYNCED = 1 AND $IMAGES_NEED_ACTIVATION = 0 AND $CREATED_TIMESTAMP < $timestamp AND $WORKSPACE_ID = $workspaceId") { it.toNoteEdit() }
 
     fun updateNoteId(oldNoteId: Long, newNoteId: Long): Int =
-        db.update(NAME, listOf(NOTE_ID to newNoteId), "$NOTE_ID = $oldNoteId")
+        db.update(NAME, listOf(NOTE_ID to newNoteId), "$NOTE_ID = $oldNoteId AND $WORKSPACE_ID = $workspaceId")
 
     fun getOldestNeedingImagesActivation(): NoteEdit? =
-        db.queryOne(NAME, where = "$IS_SYNCED = 1 AND $IMAGES_NEED_ACTIVATION = 1", orderBy = CREATED_TIMESTAMP) { it.toNoteEdit() }
+        db.queryOne(NAME, where = "$IS_SYNCED = 1 AND $IMAGES_NEED_ACTIVATION = 1 AND $WORKSPACE_ID = $workspaceId", orderBy = CREATED_TIMESTAMP) { it.toNoteEdit() }
 
     fun markImagesActivated(id: Long): Boolean =
-        db.update(NAME, listOf(IMAGES_NEED_ACTIVATION to 0), "$ID = $id") == 1
+        db.update(NAME, listOf(IMAGES_NEED_ACTIVATION to 0), "$ID = $id AND $WORKSPACE_ID = $workspaceId") == 1
 
     fun replaceTextInUnsynced(text: String, replacement: String) {
         db.exec(
-            "UPDATE $NAME SET $TEXT = replace($TEXT, ?, ?) WHERE $IS_SYNCED = 0",
-            arrayOf(text, replacement)
+            "UPDATE $NAME SET $TEXT = replace($TEXT, ?, ?) WHERE $IS_SYNCED = 0 AND $WORKSPACE_ID = ?",
+            arrayOf(text, replacement, workspaceId)
         )
     }
 
     private fun inBoundsSql(bbox: BoundingBox): String = """
         ($LATITUDE BETWEEN ${bbox.min.latitude} AND ${bbox.max.latitude}) AND
-        ($LONGITUDE BETWEEN ${bbox.min.longitude} AND ${bbox.max.longitude})
+        ($LONGITUDE BETWEEN ${bbox.min.longitude} AND ${bbox.max.longitude}) AND
+        ($WORKSPACE_ID = $workspaceId)
     """.trimIndent()
 
     private fun NoteEdit.toPairs() = listOf(
@@ -130,7 +138,8 @@ class NoteEditsDao(private val db: Database) {
         IMAGE_PATHS to Json.encodeToString(imagePaths),
         IMAGES_NEED_ACTIVATION to if (imagesNeedActivation) 1 else 0,
         TRACK to Json.encodeToString(track),
-        TYPE to action.name
+        TYPE to action.name,
+        WORKSPACE_ID to workspaceId
     )
 
     private fun CursorPosition.toNoteEdit() = NoteEdit(
@@ -144,5 +153,6 @@ class NoteEditsDao(private val db: Database) {
         getInt(IS_SYNCED) == 1,
         getInt(IMAGES_NEED_ACTIVATION) == 1,
         Json.decodeFromString(getString(TRACK)),
+        getInt(WORKSPACE_ID)
     )
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsModule.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsModule.kt
@@ -3,10 +3,10 @@ package de.westnordost.streetcomplete.data.osmnotes.edits
 import org.koin.dsl.module
 
 val noteEditsModule = module {
-    factory { NoteEditsDao(get()) }
+    factory { NoteEditsDao(get(), get()) }
 
     single { NoteEditsUploader(get(), get(), get(), get(), get(), get(), get()) }
-    single { NoteEditsController(get()) }
+    single { NoteEditsController(get(), get()) }
     single<NoteEditsSource> { get<NoteEditsController>() }
     single { NotesWithEditsSource(get(), get(), get()) }
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsTable.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsTable.kt
@@ -15,6 +15,7 @@ object NoteEditsTable {
         const val IMAGE_PATHS = "image_paths"
         const val IMAGES_NEED_ACTIVATION = "images_need_activation"
         const val TRACK = "track"
+        const val WORKSPACE_ID = "workspace_id"
     }
 
     const val CREATE = """
@@ -29,7 +30,8 @@ object NoteEditsTable {
             ${Columns.IMAGE_PATHS} text NOT NULL,
             ${Columns.IMAGES_NEED_ACTIVATION} int NOT NULL,
             ${Columns.TRACK} text NOT NULL,
-            ${Columns.TYPE} varchar(255)
+            ${Columns.TYPE} varchar(255),
+            ${Columns.WORKSPACE_ID} int NOT NULL
         );
     """
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NotesWithEditsSource.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NotesWithEditsSource.kt
@@ -141,7 +141,8 @@ class NotesWithEditsSource(
         createdTimestamp,
         null,
         Note.Status.OPEN,
-        arrayListOf(createNoteComment(NoteComment.Action.OPENED))
+        arrayListOf(createNoteComment(NoteComment.Action.OPENED)),
+        workspaceId
     )
 
     private fun NoteEdit.createNoteComment(action: NoteComment.Action = NoteComment.Action.COMMENTED): NoteComment {

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/NoteQuestsHiddenDao.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/NoteQuestsHiddenDao.kt
@@ -4,39 +4,59 @@ import de.westnordost.streetcomplete.data.CursorPosition
 import de.westnordost.streetcomplete.data.Database
 import de.westnordost.streetcomplete.data.osmnotes.notequests.NoteQuestsHiddenTable.Columns.NOTE_ID
 import de.westnordost.streetcomplete.data.osmnotes.notequests.NoteQuestsHiddenTable.Columns.TIMESTAMP
+import de.westnordost.streetcomplete.data.osmnotes.notequests.NoteQuestsHiddenTable.Columns.WORKSPACE_ID
 import de.westnordost.streetcomplete.data.osmnotes.notequests.NoteQuestsHiddenTable.NAME
+import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
 
 /** Persists which note ids should be hidden (because the user selected so) in the note quest */
-class NoteQuestsHiddenDao(private val db: Database) {
+class NoteQuestsHiddenDao(private val db: Database, private val preferences: Preferences) {
+
+    private val workspaceId
+        get() = preferences.workspaceId ?: 0
 
     fun add(noteId: Long) {
-        db.insert(NAME, listOf(
-            NOTE_ID to noteId,
-            TIMESTAMP to nowAsEpochMilliseconds()
-        ))
+        db.insert(
+            NAME, listOf(
+                NOTE_ID to noteId,
+                TIMESTAMP to nowAsEpochMilliseconds(),
+                WORKSPACE_ID to workspaceId
+            )
+        )
     }
 
     fun getTimestamp(noteId: Long): Long? =
-        db.queryOne(NAME, where = "$NOTE_ID = $noteId") { it.getLong(TIMESTAMP) }
+        db.queryOne(
+            NAME,
+            where = "$NOTE_ID = $noteId AND $WORKSPACE_ID = $workspaceId"
+        ) { it.getLong(TIMESTAMP) }
 
     fun delete(noteId: Long): Boolean =
-        db.delete(NAME, where = "$NOTE_ID = $noteId") == 1
+        db.delete(NAME, where = "$NOTE_ID = $noteId AND $WORKSPACE_ID = $workspaceId") == 1
 
     fun getNewerThan(timestamp: Long): List<NoteQuestHiddenAt> =
-        db.query(NAME, where = "$TIMESTAMP > $timestamp") { it.toNoteQuestHiddenAt() }
+        db.query(
+            NAME,
+            where = "$TIMESTAMP > $timestamp AND $WORKSPACE_ID = $workspaceId"
+        ) { it.toNoteQuestHiddenAt() }
 
     fun getAll(): List<NoteQuestHiddenAt> =
-        db.query(NAME) { it.toNoteQuestHiddenAt() }
+        db.query(NAME, where = "$WORKSPACE_ID = $workspaceId") { it.toNoteQuestHiddenAt() }
 
     fun deleteAll(): Int =
-        db.delete(NAME)
+        db.delete(NAME, where = "$WORKSPACE_ID = $workspaceId")
 
     fun countAll(): Int =
-        db.queryOne(NAME, columns = arrayOf("COUNT(*)")) { it.getInt("COUNT(*)") } ?: 0
+        db.queryOne(
+            NAME, where = "$WORKSPACE_ID = $workspaceId",
+            columns = arrayOf("COUNT(*)")
+        ) { it.getInt("COUNT(*)") } ?: 0
 }
 
 private fun CursorPosition.toNoteQuestHiddenAt() =
-    NoteQuestHiddenAt(getLong(NOTE_ID), getLong(TIMESTAMP))
+    NoteQuestHiddenAt(
+        getLong(NOTE_ID),
+        getLong(TIMESTAMP), getInt(WORKSPACE_ID)
+    )
 
-data class NoteQuestHiddenAt(val noteId: Long, val timestamp: Long)
+data class NoteQuestHiddenAt(val noteId: Long, val timestamp: Long, val workspaceId: Int)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/NoteQuestsHiddenTable.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/NoteQuestsHiddenTable.kt
@@ -6,12 +6,14 @@ object NoteQuestsHiddenTable {
     object Columns {
         const val NOTE_ID = "note_id"
         const val TIMESTAMP = "timestamp"
+        const val WORKSPACE_ID = "workspace_id"
     }
 
     const val CREATE = """
         CREATE TABLE $NAME (
             ${Columns.NOTE_ID} INTEGER PRIMARY KEY,
-            ${Columns.TIMESTAMP} int NOT NULL
+            ${Columns.TIMESTAMP} int NOT NULL,
+            ${Columns.WORKSPACE_ID} int NOT NULL
         );
     """
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuest.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuest.kt
@@ -8,4 +8,4 @@ interface OsmNoteQuest : Quest {
     val id: Long
 }
 
-expect fun createOsmNoteQuest(id: Long, position: LatLon): OsmNoteQuest
+expect fun createOsmNoteQuest(id: Long, position: LatLon, workspaceId : Int): OsmNoteQuest

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestController.kt
@@ -21,6 +21,8 @@ class OsmNoteQuestController(
     /* Must be a singleton because there is a listener that should respond to a change in the
      *  database table */
 
+    private val workspaceId
+        get() = prefs.workspaceId ?: 0
     private val listeners = Listeners<OsmNoteQuestSource.Listener>()
 
     private val showOnlyNotesPhrasedAsQuestions: Boolean get() =
@@ -78,7 +80,7 @@ class OsmNoteQuestController(
 
     private fun createQuestForNote(note: Note): OsmNoteQuest? =
         if (note.shouldShowAsQuest(userDataSource.userId, showOnlyNotesPhrasedAsQuestions)) {
-            createOsmNoteQuest(note.id, note.position)
+            createOsmNoteQuest(note.id, note.position, workspaceId)
         } else {
             null
         }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestHidden.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestHidden.kt
@@ -15,4 +15,6 @@ data class OsmNoteQuestHidden(
     override val isUndoable: Boolean get() = true
     override val position: LatLon get() = note.position
     override val isSynced: Boolean? get() = null
+    override val workspaceId: Int
+        get() = note.workspaceId
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestModule.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/notequests/OsmNoteQuestModule.kt
@@ -3,7 +3,7 @@ package de.westnordost.streetcomplete.data.osmnotes.notequests
 import org.koin.dsl.module
 
 val osmNoteQuestModule = module {
-    factory { NoteQuestsHiddenDao(get()) }
+    factory { NoteQuestsHiddenDao(get(), get()) }
 
     single<OsmNoteQuestSource> { get<OsmNoteQuestController>() }
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/quest/Quest.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/quest/Quest.kt
@@ -16,4 +16,6 @@ interface Quest {
     val geometry: ElementGeometry
     /** The type of the quest */
     val type: QuestType
+
+    var workspaceId : Int
 }

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/quest/QuestKey.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/quest/QuestKey.kt
@@ -16,5 +16,6 @@ data class OsmNoteQuestKey(val noteId: Long) : QuestKey()
 data class OsmQuestKey(
     val elementType: ElementType,
     val elementId: Long,
-    val questTypeName: String
+    val questTypeName: String,
+    var workspaceId: Int
 ) : QuestKey()

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/visiblequests/QuestsHiddenController.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/visiblequests/QuestsHiddenController.kt
@@ -22,14 +22,19 @@ class QuestsHiddenController(
 
     // the cache must be in-sync with the db
     private val cacheLock = ReentrantLock()
-    private val cache: MutableMap<QuestKey, Long> by lazy {
+    private val cache: MutableMap<QuestKey, Long> = HashMap()
+
+    init {
+        refreshCache()
+    }
+
+    fun refreshCache() {
         cacheLock.withLock {
+            cache.clear()
             val allOsmHidden = osmDb.getAll()
             val allNotesHidden = notesDb.getAll()
-            val result = HashMap<QuestKey, Long>(allOsmHidden.size + allNotesHidden.size)
-            allOsmHidden.forEach { result[it.key] = it.timestamp }
-            allNotesHidden.forEach { result[OsmNoteQuestKey(it.noteId)] = it.timestamp }
-            result
+            allOsmHidden.forEach { cache[it.key] = it.timestamp }
+            allNotesHidden.forEach { cache[OsmNoteQuestKey(it.noteId)] = it.timestamp }
         }
     }
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/edithistory/EditHistoryViewModel.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/edithistory/EditHistoryViewModel.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
+import kotlin.time.ExperimentalTime
 
 @Stable
 abstract class EditHistoryViewModel : ViewModel() {
@@ -166,6 +167,7 @@ class EditHistoryViewModelImpl(
         }
     }
 
+    @OptIn(ExperimentalTime::class)
     private fun List<Edit>.toEditItems(): List<EditItem> {
         var editAboveDateTime: LocalDateTime? = null
         return map { edit ->

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/edithistory/EditHistoryViewModel.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/edithistory/EditHistoryViewModel.kt
@@ -49,6 +49,8 @@ abstract class EditHistoryViewModel : ViewModel() {
     //      compose <-> fragment communication necessary anymore
     abstract fun showSidebar()
     abstract fun hideSidebar()
+
+    abstract fun refreshForNewWorkspace()
     abstract val isShowingSidebar: StateFlow<Boolean>
 }
 
@@ -108,6 +110,11 @@ class EditHistoryViewModelImpl(
     override fun hideSidebar() {
         selectedEdit.value = null
         isShowingSidebar.value = false
+    }
+
+    override fun refreshForNewWorkspace() {
+        // updateEdits()
+        editHistoryController.refresh()
     }
 
     override val isShowingSidebar = MutableStateFlow<Boolean>(false)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/SpatialCache.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/util/SpatialCache.kt
@@ -85,6 +85,7 @@ class SpatialCache<K, T>(
             // because all tiles that are in cache must be complete
             val tile = byTile[item.getTilePos()] ?: continue
             tile.add(item)
+            Log.d("SpatialCache", "Added item ${item.getKey()} to cache in tile $tile")
             byKey[item.getKey()] = item
         }
     } }

--- a/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osmnotes/NotesApiParserTest.kt
+++ b/app/src/commonTest/kotlin/de/westnordost/streetcomplete/data/osmnotes/NotesApiParserTest.kt
@@ -32,7 +32,10 @@ class NotesApiParserTest {
             comments = listOf()
         )
 
-        assertEquals(listOf(note), NotesApiParser().parseNotes(buffer))
+        assertEquals(listOf(note), NotesApiParser().parseNotes(
+            buffer,
+            workspaceConfigProvider.workspaceId
+        ))
     }
 
     @Test fun `parse one full note`() {
@@ -89,7 +92,10 @@ class NotesApiParserTest {
             )
         )
 
-        assertEquals(listOf(note), NotesApiParser().parseNotes(buffer))
+        assertEquals(listOf(note), NotesApiParser().parseNotes(
+            buffer,
+            workspaceConfigProvider.workspaceId
+        ))
     }
 
     @Test fun `parse several notes`() {
@@ -129,7 +135,7 @@ class NotesApiParserTest {
             ),
         )
 
-        assertEquals(notes, NotesApiParser().parseNotes(buffer))
+        assertEquals(notes, NotesApiParser().parseNotes(buffer, workspaceConfigProvider.workspaceId))
     }
 
     @Test fun `parse note with XML entity refs`() {
@@ -156,7 +162,7 @@ class NotesApiParserTest {
             """.trimIndent()
         )
 
-        val comment = NotesApiParser().parseNotes(buffer)[0].comments[0]
+        val comment = NotesApiParser().parseNotes(buffer, workspaceConfigProvider.workspaceId)[0].comments[0]
 
         assertEquals("dude & <dudette>", comment.user?.displayName)
         assertEquals("I opened it & \"nothing\" broke!", comment.text)


### PR DESCRIPTION
This pull request updates several components to consistently handle the `workspaceId` property for quests and edits throughout the app. The changes ensure that quest and edit keys, data classes, and manager classes all pass and use the correct workspace context, which is necessary for multi-workspace support and correct quest management. Additionally, there are minor UI adjustments and test updates to reflect these changes.

**Workspace ID propagation and handling:**

* Updated constructors and usages of `OsmQuestKey` and related data classes to include the `workspaceId` parameter, ensuring all quest and edit operations are workspace-aware. [[1]](diffhunk://#diff-129f9cccaf7609039a8d5c6754b590da716d071ba6b4a11b3bc508c2adbf0973L25-R25) [[2]](diffhunk://#diff-129f9cccaf7609039a8d5c6754b590da716d071ba6b4a11b3bc508c2adbf0973L35-R36) [[3]](diffhunk://#diff-129f9cccaf7609039a8d5c6754b590da716d071ba6b4a11b3bc508c2adbf0973L48-R49) [[4]](diffhunk://#diff-129f9cccaf7609039a8d5c6754b590da716d071ba6b4a11b3bc508c2adbf0973L61-R62) [[5]](diffhunk://#diff-129f9cccaf7609039a8d5c6754b590da716d071ba6b4a11b3bc508c2adbf0973L72-R72) [[6]](diffhunk://#diff-4a431ea9131083f5b91b7cd30300ad11d9e23d50b60647141207680c4226393dL14-R24) [[7]](diffhunk://#diff-5c98b48311c4d6f7dcbc29724bc90c4f007d62e12a77f0edb8c7314e2ce17ec1L83-R83) [[8]](diffhunk://#diff-f1de01edf9b14d8aa87e399f1c3c5e38714de36b69228b9dedf250bbd5409e54L45-R45)
* Modified `EditHistoryPinsManager` and `QuestPinsManager` to accept and use `Preferences` for retrieving the current `workspaceId`, and updated their key conversion logic to include workspace context. [[1]](diffhunk://#diff-75252c8d57c458539b0d4b5b70025a7e0bcca282c2d801da62904d9e72e30a27R16) [[2]](diffhunk://#diff-75252c8d57c458539b0d4b5b70025a7e0bcca282c2d801da62904d9e72e30a27R33) [[3]](diffhunk://#diff-75252c8d57c458539b0d4b5b70025a7e0bcca282c2d801da62904d9e72e30a27L82-R84) [[4]](diffhunk://#diff-75252c8d57c458539b0d4b5b70025a7e0bcca282c2d801da62904d9e72e30a27L139-R141) [[5]](diffhunk://#diff-75252c8d57c458539b0d4b5b70025a7e0bcca282c2d801da62904d9e72e30a27L148-R151) [[6]](diffhunk://#diff-58dcbe36023088600d3f5d2b1fe8d00e0edf46cbffee1b8e13af4234be3ab40eR21) [[7]](diffhunk://#diff-58dcbe36023088600d3f5d2b1fe8d00e0edf46cbffee1b8e13af4234be3ab40eR66) [[8]](diffhunk://#diff-58dcbe36023088600d3f5d2b1fe8d00e0edf46cbffee1b8e13af4234be3ab40eR113-R115) [[9]](diffhunk://#diff-58dcbe36023088600d3f5d2b1fe8d00e0edf46cbffee1b8e13af4234be3ab40eL166-R171) [[10]](diffhunk://#diff-58dcbe36023088600d3f5d2b1fe8d00e0edf46cbffee1b8e13af4234be3ab40eR244) [[11]](diffhunk://#diff-58dcbe36023088600d3f5d2b1fe8d00e0edf46cbffee1b8e13af4234be3ab40eL429-R444) [[12]](diffhunk://#diff-5646c8ede74a669b83b6bd62a8abcc2fce17357c7d61945b545e36a3b17e572cL303-R309)
* Updated quest and edit creation and display logic to pass the `workspaceId` where necessary, including in UI calls and navigation. [[1]](diffhunk://#diff-3578f07919a8dfbab2b3608653af79c4f6e56425958545ebd339ede9fd934aa1L1186-R1186) [[2]](diffhunk://#diff-d7b658faa9bf55069860c9814f75712491c1d92d1b865bcf6cf817234ebce1b8R291) [[3]](diffhunk://#diff-cee98c55f34ec9cb42256ba5db7b34054390b4cef2312b4c5d85df3ffd767eb0R56-R66) [[4]](diffhunk://#diff-cee98c55f34ec9cb42256ba5db7b34054390b4cef2312b4c5d85df3ffd767eb0L123) [[5]](diffhunk://#diff-cee98c55f34ec9cb42256ba5db7b34054390b4cef2312b4c5d85df3ffd767eb0R179) [[6]](diffhunk://#diff-cee98c55f34ec9cb42256ba5db7b34054390b4cef2312b4c5d85df3ffd767eb0L198-R203) [[7]](diffhunk://#diff-cee98c55f34ec9cb42256ba5db7b34054390b4cef2312b4c5d85df3ffd767eb0L314-R319)

**UI and layout changes:**

* Removed unused or redundant UI elements from the `form_leave_note.xml` layout, simplifying the note creation form and adjusting margins for better spacing. [[1]](diffhunk://#diff-07d5601001d3be3d3c85d62f248416a4f51b59d8f0eaa0f8d2937c998c74365dL15-L21) [[2]](diffhunk://#diff-07d5601001d3be3d3c85d62f248416a4f51b59d8f0eaa0f8d2937c998c74365dR23-L39)

**Testing and preview updates:**

* Updated test and preview data helpers to include `workspaceId` in quest key creation, ensuring tests reflect the new data structure. [[1]](diffhunk://#diff-129f9cccaf7609039a8d5c6754b590da716d071ba6b4a11b3bc508c2adbf0973L25-R25) [[2]](diffhunk://#diff-129f9cccaf7609039a8d5c6754b590da716d071ba6b4a11b3bc508c2adbf0973L35-R36) [[3]](diffhunk://#diff-129f9cccaf7609039a8d5c6754b590da716d071ba6b4a11b3bc508c2adbf0973L48-R49) [[4]](diffhunk://#diff-129f9cccaf7609039a8d5c6754b590da716d071ba6b4a11b3bc508c2adbf0973L61-R62) [[5]](diffhunk://#diff-129f9cccaf7609039a8d5c6754b590da716d071ba6b4a11b3bc508c2adbf0973L72-R72) [[6]](diffhunk://#diff-f1de01edf9b14d8aa87e399f1c3c5e38714de36b69228b9dedf250bbd5409e54L45-R45) [[7]](diffhunk://#diff-5c98b48311c4d6f7dcbc29724bc90c4f007d62e12a77f0edb8c7314e2ce17ec1L83-R83)

**ViewModel and composable changes:**

* Added a `refreshForNewWorkspace` method to `EditHistoryViewModel` and ensured it is called when switching workspaces to update state accordingly. [[1]](diffhunk://#diff-e17f6fdbc567395ac6a70cbe552113808aea79dd572e02e7d85265b37c0a0224R554-R557) [[2]](diffhunk://#diff-cee98c55f34ec9cb42256ba5db7b34054390b4cef2312b4c5d85df3ffd767eb0R56-R66) [[3]](diffhunk://#diff-cee98c55f34ec9cb42256ba5db7b34054390b4cef2312b4c5d85df3ffd767eb0R179)

These changes collectively improve the app's support for multiple workspaces, ensuring that all quest and edit operations are properly scoped and managed.