### PR TITLE
image selection UI and improve image loading logic with shared ImageLoader

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,8 +9,8 @@ import java.util.Properties
 
 
 /** App version name, code and flavor */
-val appVersionName = "1.2.3"
-val appVersionCode = 13
+val appVersionName = "1.2.4"
+val appVersionCode = 14
 
 /** Localizations the app should be available in */
 val bcp47ExportLanguages = setOf(

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk_long_form/data/LongFormAdapter.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk_long_form/data/LongFormAdapter.kt
@@ -329,6 +329,22 @@ class LongFormAdapter<T>(val cameraIntent: () -> Unit) :
         val binding: CellLongFormItemImageGridBinding,
         val allowMultiChoice: Boolean,
     ) : ViewHolder(binding.root) {
+
+        // Created once and reused across rebinds. Replacing binding.list.adapter on every bind
+        // (which happens whenever this question is in needRefreshIds and any answer changes)
+        // forced the inner RecyclerView to recycle its ImageViews into a brand new adapter
+        // instance, which could let an in-flight image load for the old item land on the
+        // recycled view after it was rebound to a different item.
+        private val imageSelectAdapter =
+            ImageSelectAdapter<LongFormQuest>(if (allowMultiChoice) -1 else 1)
+        private var selectionListener: ImageSelectAdapter.OnItemSelectionListener? = null
+
+        init {
+            binding.list.layoutManager = GridLayoutManager(binding.root.context, 3)
+            binding.list.isNestedScrollingEnabled = false
+            binding.list.adapter = imageSelectAdapter
+        }
+
         fun bind(item: LongFormQuest, position: Int) {
 
             binding.title.text = item.questTitle
@@ -348,18 +364,15 @@ class LongFormAdapter<T>(val cameraIntent: () -> Unit) :
             }
 
             binding.description.text = item.questDescription
-            val imageSelectAdapter =
-                ImageSelectAdapter<LongFormQuest>(if (allowMultiChoice) -1 else 1)
-            binding.list.layoutManager = GridLayoutManager(binding.root.context, 3)
-            binding.list.isNestedScrollingEnabled = false
-            binding.list.adapter = imageSelectAdapter
             binding.choiceFollowUp.setOnClickListener {
                 cameraIntent()
             }
 
             imageSelectAdapter.selectedIndices =
                 item.selectedIndex ?: emptyList()
-            imageSelectAdapter.listeners.add(object : ImageSelectAdapter.OnItemSelectionListener {
+
+            selectionListener?.let { imageSelectAdapter.listeners.remove(it) }
+            val listener = object : ImageSelectAdapter.OnItemSelectionListener {
                 override fun onIndexSelected(index: Int) {
                     // checkIsFormComplete()
                     handleSelection(
@@ -435,8 +448,9 @@ class LongFormAdapter<T>(val cameraIntent: () -> Unit) :
 
                     dialog.show()
                 }
-            })
-
+            }
+            imageSelectAdapter.listeners.add(listener)
+            selectionListener = listener
 
             imageSelectAdapter.items = item.questAnswerChoices?.map {
                 Item2(

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/view/Image.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/view/Image.kt
@@ -5,18 +5,14 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.ProgressBar
 import androidx.annotation.DrawableRes
-import coil.Coil.setImageLoader
 import coil.ImageLoader
 import coil.disk.DiskCache
+import coil.dispose
 import coil.load
 import coil.request.CachePolicy
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.preferences.Preferences
-import de.westnordost.streetcomplete.util.logs.Log
-import okhttp3.OkHttpClient
-import org.koin.android.ext.android.inject
 import org.koin.java.KoinJavaComponent.inject
-import kotlin.getValue
 
 /* Same idea here as the Icon class introduced in min API level 23. If the min API level is
    Build.VERSION_CODES_M, usage of this class can be replaced with Icon */
@@ -26,49 +22,55 @@ data class ResImage(@DrawableRes val resId: Int) : Image
 data class DrawableImage(val drawable: Drawable) : Image
 data class ImageUrl(val url: String? = "https://picsum.photos/320/480") : Image
 
-fun ImageView.setImage(image: Image?, imageIsEmptyUpdateTextSize: () -> Unit = {}, progressBar: ProgressBar? = null) {
-    val preferences: Preferences by inject(Preferences::class.java)
+// Built once and reused for every load. Building a new ImageLoader (and DiskCache pointed at the
+// same cache directory) per bind caused concurrent DiskCache instances to fight over the same
+// cache journal, so most simultaneous loads (e.g. several grid cells sharing one URL) silently failed.
+private var sharedImageLoader: ImageLoader? = null
 
-    val customImageLoader = ImageLoader.Builder(context)
-        .okHttpClient {
-            OkHttpClient.Builder()
-                .addInterceptor { chain ->
-                    val newRequest = chain.request().newBuilder()
-                        .build()
-                    chain.proceed(newRequest)
-                }
-                .build()
-        }
+private fun sharedImageLoader(context: android.content.Context): ImageLoader =
+    sharedImageLoader ?: ImageLoader.Builder(context.applicationContext)
         .diskCache {
             DiskCache.Builder()
-                .directory(context.cacheDir.resolve("image_cache"))
+                .directory(context.applicationContext.cacheDir.resolve("image_cache"))
                 .maxSizePercent(0.02) // 2% of app storage
                 .build()
         }
         .memoryCachePolicy(CachePolicy.ENABLED)
         .networkCachePolicy(CachePolicy.ENABLED)
         .build()
+        .also { sharedImageLoader = it }
+
+fun ImageView.setImage(
+    image: Image?,
+    imageIsEmptyUpdateTextSize: () -> Unit = {},
+    progressBar: ProgressBar? = null,
+) {
+    val preferences: Preferences by inject(Preferences::class.java)
 
     when (image) {
         is ResImage -> {
+            this.dispose()
             progressBar?.visibility = View.GONE
             setImageResource(image.resId)
         }
+
         is DrawableImage -> {
+            this.dispose()
             progressBar?.visibility = View.GONE
             setImageDrawable(image.drawable)
         }
+
         is ImageUrl -> {
             val url = image.url
             if (url.isNullOrEmpty() || preferences.isLowBandwidthModeEnabled) {
+                this.dispose()
                 progressBar?.visibility = View.GONE
                 setImageResource(R.drawable.blank_big)
                 imageIsEmptyUpdateTextSize()
             } else {
                 // Show progress bar when starting to load from URL
                 progressBar?.visibility = View.VISIBLE
-                this.load(url) {
-                    setImageLoader(customImageLoader)
+                this.load(url, sharedImageLoader(context)) {
                     placeholder(R.drawable.blank_big)
                     error(R.drawable.blank_big)
                     listener(
@@ -88,6 +90,7 @@ fun ImageView.setImage(image: Image?, imageIsEmptyUpdateTextSize: () -> Unit = {
         }
 
         null -> {
+            this.dispose()
             progressBar?.visibility = View.GONE
             setImageDrawable(null)
         }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/view/image_select/ItemViewHolder.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/view/image_select/ItemViewHolder.kt
@@ -4,7 +4,6 @@ import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.ImageView
 import android.widget.ProgressBar
-import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.view.isGone
 import androidx.recyclerview.widget.RecyclerView
@@ -18,8 +17,8 @@ class ItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
     private val textView: OutlinedTextView? = itemView.findViewById(R.id.textView)
     private val descriptionView: TextView? = itemView.findViewById(R.id.descriptionView)
 
-    private val onlyTextView : TextView? = itemView.findViewById(R.id.textWithoutImage)
-    private val progressBar : ProgressBar? = itemView.findViewById(R.id.progress_bar)
+    private val onlyTextView: TextView? = itemView.findViewById(R.id.textWithoutImage)
+    private val progressBar: ProgressBar? = itemView.findViewById(R.id.progress_bar)
     private val dropDownArrowImageView: ImageView? =
         itemView.findViewById(R.id.dropDownArrowImageView)
 
@@ -63,6 +62,8 @@ class ItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         }
 
     fun bind(item: DisplayItem<*>) {
+        onlyTextView?.visibility = View.GONE
+        textView?.visibility = View.VISIBLE
         imageView?.setImage(
             item.image,
             imageIsEmptyUpdateTextSize = {
@@ -71,7 +72,8 @@ class ItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
                     it.setText(item.title)
                     textView?.visibility = View.GONE
                 }
-            }, progressBar)
+            }, progressBar
+        )
         textView?.setText(item.title)
         descriptionView?.setText(item.description)
         descriptionView?.isGone = item.description == null

--- a/app/src/androidMain/res/layout/cell_labeled_image_select.xml
+++ b/app/src/androidMain/res/layout/cell_labeled_image_select.xml
@@ -20,7 +20,7 @@
     <TextView
         android:id="@+id/textWithoutImage"
         android:layout_centerInParent="true"
-        android:textSize="20sp"
+        android:textSize="14sp"
         android:textStyle="bold"
         android:textColor="@color/text"
         android:textAlignment="center"


### PR DESCRIPTION
Version bump
This pull request introduces several improvements focused on image handling, adapter stability, and UI consistency. The most significant changes include optimizing image loading to prevent cache conflicts and memory issues, fixing RecyclerView adapter reuse to avoid image misplacement, and ensuring correct view visibility and text sizing in image selection grids.

**Image Loading Improvements:**

* Refactored `setImage` in `Image.kt` to use a shared `ImageLoader` instance, preventing concurrent cache access issues that previously caused image loads to fail when multiple images with the same URL were loaded simultaneously. Added explicit disposal of images on view reuse to avoid memory leaks and incorrect image displays. (`app/src/androidMain/kotlin/de/westnordost/streetcomplete/view/Image.kt`) [[1]](diffhunk://#diff-72d96ca65ebdb257c988e6db0fca7e83cdbefd9be8e24dee142073a40688c25bL8-L19) [[2]](diffhunk://#diff-72d96ca65ebdb257c988e6db0fca7e83cdbefd9be8e24dee142073a40688c25bL29-R73) [[3]](diffhunk://#diff-72d96ca65ebdb257c988e6db0fca7e83cdbefd9be8e24dee142073a40688c25bR93)

**RecyclerView Adapter Stability:**

* Updated `LongFormAdapter` to create and reuse a single `ImageSelectAdapter` per ViewHolder instead of recreating it on every bind. This prevents recycled views from displaying images meant for previously bound items and fixes issues with in-flight image loads landing on the wrong view. Also, managed selection listeners to avoid leaks and duplicate callbacks. (`app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk_long_form/data/LongFormAdapter.kt`) [[1]](diffhunk://#diff-6ace3085a0f3a6c98c9e996716429a5cbed63fc503ed17c3f9014c7d13f7a721R332-R347) [[2]](diffhunk://#diff-6ace3085a0f3a6c98c9e996716429a5cbed63fc503ed17c3f9014c7d13f7a721L351-R375) [[3]](diffhunk://#diff-6ace3085a0f3a6c98c9e996716429a5cbed63fc503ed17c3f9014c7d13f7a721L438-R453)

**UI and View Consistency:**

* Ensured correct visibility for text views in image selection items, addressing cases where text-only or image-with-text cells were not displayed as intended. (`app/src/androidMain/kotlin/de/westnordost/streetcomplete/view/image_select/ItemViewHolder.kt`)
* Reduced the text size for the `textWithoutImage` view in image selection cells from 20sp to 14sp for improved UI consistency. (`app/src/androidMain/res/layout/cell_labeled_image_select.xml`)

**Version Update:**

* Incremented the app version to 1.2.4 (code 14). (`app/build.gradle.kts`)