### PR TITLE
Flip upload button icon horizontally for better visual alignment

### DIFF
--- a/app/src/androidMain/res/layout/view_upload_button.xml
+++ b/app/src/androidMain/res/layout/view_upload_button.xml
@@ -10,6 +10,7 @@
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:contentDescription="@string/sync_changes"
+        android:scaleX="-1"
         app:srcCompat="@drawable/ic_outline_sync"
         app:tint="#2D0369" />
 


### PR DESCRIPTION
This pull request makes a small UI adjustment to the upload button in the Android app layout. The change horizontally flips the sync icon to improve its visual alignment or meaning.

* [`view_upload_button.xml`](diffhunk://#diff-643c5b16b5aeb8251fe0a7dba8dd4bd441cf329aceaef9bc80cc617aef46d7baR13): Added `android:scaleX="-1"` to the sync icon, horizontally mirroring the image.
[Screen_recording_20260629_172922.webm](https://github.com/user-attachments/assets/151be20d-0514-4854-bdbf-532608e8acde)
