### PR TITLE
Update environment endpoints  add "Forgot password?" link in login screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,8 +9,8 @@ import java.util.Properties
 
 
 /** App version name, code and flavor */
-val appVersionName = "1.2.4"
-val appVersionCode = 14
+val appVersionName = "1.2.6"
+val appVersionCode = 15
 
 /** Localizations the app should be available in */
 val bcp47ExportLanguages = setOf(

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
@@ -170,7 +170,7 @@ suspend fun refreshJwtToken(
         }
 
         val response =
-            tempClient.post(environmentManager.currentEnvironment.tdeiUserManagementEndpoint + "/refresh-token") {
+            tempClient.post(environmentManager.currentEnvironment.tdeiApiBaseUrl + "/refresh-token") {
                 setBody(preferences.workspaceRefreshToken)
                 headers {
                     contentType(ContentType.Application.Json)

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
@@ -170,7 +170,7 @@ suspend fun refreshJwtToken(
         }
 
         val response =
-            tempClient.post(environmentManager.currentEnvironment.loginUrl + "/refresh-token") {
+            tempClient.post(environmentManager.currentEnvironment.tdeiUserManagementEndpoint + "/refresh-token") {
                 setBody(preferences.workspaceRefreshToken)
                 headers {
                     contentType(ContentType.Application.Json)

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/data/workspace/data/remote/WorkspaceApiService.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/data/workspace/data/remote/WorkspaceApiService.kt
@@ -64,7 +64,7 @@ class WorkspaceApiService(
     }
 
     suspend fun getTDEIUserDetails(emailId: String): UserInfoResponse {
-        val url = environmentManager.currentEnvironment.tdeiUrl
+        val url = environmentManager.currentEnvironment.tdeiApiUrl
 
         try {
             val response = performHttpCallWithFirebaseTracing(
@@ -107,7 +107,7 @@ class WorkspaceApiService(
     }
 
     suspend fun loginToWorkspace(username: String, password: String): LoginResponse {
-        val url = environmentManager.currentEnvironment.loginUrl + "/authenticate"
+        val url = environmentManager.currentEnvironment.tdeiUserManagementEndpoint + "/authenticate"
         try {
             val response = performHttpCallWithFirebaseTracing(
                 client = httpClient,
@@ -145,7 +145,7 @@ class WorkspaceApiService(
     }
 
     suspend fun refreshToken(refreshToken: String): LoginResponse {
-        val url = environmentManager.currentEnvironment.loginUrl + "/refresh-token"
+        val url = environmentManager.currentEnvironment.tdeiUserManagementEndpoint + "/refresh-token"
         try {
 
             val response = performHttpCallWithFirebaseTracing(

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/data/workspace/data/remote/WorkspaceApiService.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/data/workspace/data/remote/WorkspaceApiService.kt
@@ -64,7 +64,7 @@ class WorkspaceApiService(
     }
 
     suspend fun getTDEIUserDetails(emailId: String): UserInfoResponse {
-        val url = environmentManager.currentEnvironment.tdeiApiUrl
+        val url = environmentManager.currentEnvironment.tdeiUserManagementBaseurl
 
         try {
             val response = performHttpCallWithFirebaseTracing(
@@ -107,7 +107,7 @@ class WorkspaceApiService(
     }
 
     suspend fun loginToWorkspace(username: String, password: String): LoginResponse {
-        val url = environmentManager.currentEnvironment.tdeiUserManagementEndpoint + "/authenticate"
+        val url = environmentManager.currentEnvironment.tdeiApiBaseUrl + "/authenticate"
         try {
             val response = performHttpCallWithFirebaseTracing(
                 client = httpClient,
@@ -145,7 +145,7 @@ class WorkspaceApiService(
     }
 
     suspend fun refreshToken(refreshToken: String): LoginResponse {
-        val url = environmentManager.currentEnvironment.tdeiUserManagementEndpoint + "/refresh-token"
+        val url = environmentManager.currentEnvironment.tdeiApiBaseUrl + "/refresh-token"
         try {
 
             val response = performHttpCallWithFirebaseTracing(

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkspaceLoginScreen.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkspaceLoginScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -58,7 +59,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
@@ -456,6 +456,20 @@ fun LoginCard(
                     modifier = Modifier
                         .fillMaxWidth()
                 )
+
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = {
+                        // open URL in browser
+                        val url =
+                            selectedEnvironment.value.tdeiWebUrl + "/ForgotPassword"
+                        val intent = Intent(Intent.ACTION_VIEW)
+                        intent.data = url.toUri()
+                        context.startActivity(intent)
+                    }) {
+                        Text("Forgot password?", color = MaterialTheme.colorScheme.primary)
+                    }
+                }
+
                 if (isDebugModeEnabled) {
                     EnvironmentDropdownMenu(viewModel, selectedEnvironment, modifier = Modifier)
                 }
@@ -497,7 +511,7 @@ fun LoginCard(
 fun UserInfoComponent() {
     Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         val context = LocalContext.current

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/preferences/WorkspaceConstants.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/preferences/WorkspaceConstants.kt
@@ -2,8 +2,8 @@ package de.westnordost.streetcomplete.data.preferences
 
 enum class Environment(
     val baseUrl: String,
-    val tdeiUserManagementEndpoint: String,
-    val tdeiApiUrl: String,
+    val tdeiApiBaseUrl: String,
+    val tdeiUserManagementBaseurl: String,
     val osmUrl: String,
     val tdeiWebUrl: String,
     val appUpdateVersionCheckUrl: String = APP_UPDATE_VERSION_CHECKER_URL,

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/preferences/WorkspaceConstants.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/preferences/WorkspaceConstants.kt
@@ -2,9 +2,10 @@ package de.westnordost.streetcomplete.data.preferences
 
 enum class Environment(
     val baseUrl: String,
-    val loginUrl: String,
-    val tdeiUrl: String,
+    val tdeiUserManagementEndpoint: String,
+    val tdeiApiUrl: String,
     val osmUrl: String,
+    val tdeiWebUrl: String,
     val appUpdateVersionCheckUrl: String = APP_UPDATE_VERSION_CHECKER_URL,
     val firebaseUpdateUrl: String = FIREBASE_UPDATE_URL
 ) {
@@ -12,19 +13,22 @@ enum class Environment(
         "https://api.workspaces-stage.sidewalks.washington.edu/api/v1/workspaces",
         "https://tdei-gateway-stage.azurewebsites.net/api/v1",
         "https://tdei-usermanagement-stage.azurewebsites.net/api/v1/user-profile",
-        "https://osm-workspaces-proxy.azurewebsites.net/stage/api/0.6/"
+        "https://osm-workspaces-proxy.azurewebsites.net/stage/api/0.6/",
+        "https://portal-stage.tdei.us"
     ),
     DEV(
         "https://api.workspaces-dev.sidewalks.washington.edu/api/v1/workspaces",
         "https://tdei-api-dev.azurewebsites.net/api/v1",
         "https://tdei-usermanagement-be-dev.azurewebsites.net/api/v1/user-profile",
-        "https://osm-workspaces-proxy.azurewebsites.net/dev/api/0.6/"
+        "https://osm-workspaces-proxy.azurewebsites.net/dev/api/0.6/",
+        "https://portal-dev.tdei.us"
     ),
     PROD(
         "https://api.workspaces.sidewalks.washington.edu/api/v1/workspaces",
         "https://tdei-gateway-prod.azurewebsites.net/api/v1",
         "https://tdei-usermanagement-prod.azurewebsites.net/api/v1/user-profile",
-        "https://osm-workspaces-proxy.azurewebsites.net/prod/api/0.6/"
+        "https://osm-workspaces-proxy.azurewebsites.net/prod/api/0.6/",
+        "https://portal.tdei.us"
     );
 
     companion object {


### PR DESCRIPTION
This pull request introduces several improvements and updates to the workspace authentication flow and environment configuration. The most significant changes include updating environment URLs for better separation of API and user management endpoints, updating the app version, and enhancing the login UI with a "Forgot password?" link.

**Environment and API URL Refactoring:**
- Refactored the `Environment` enum in `WorkspaceConstants.kt` to replace `loginUrl` and `tdeiUrl` with `tdeiApiBaseUrl` and `tdeiUserManagementBaseurl`, and added `tdeiWebUrl` for each environment. This provides clearer separation and easier management of service endpoints.
- Updated all authentication and user info API calls in `WorkspaceApiService.kt` and `ApplicationModule.kt` to use the new `tdeiApiBaseUrl` and `tdeiUserManagementBaseurl` properties instead of the old URLs. [[1]](diffhunk://#diff-299a2dcc24eb36a61d72a3933f6f870077bc04273e97f31c3d72fdcfb70c084cL67-R67) [[2]](diffhunk://#diff-299a2dcc24eb36a61d72a3933f6f870077bc04273e97f31c3d72fdcfb70c084cL110-R110) [[3]](diffhunk://#diff-299a2dcc24eb36a61d72a3933f6f870077bc04273e97f31c3d72fdcfb70c084cL148-R148) [[4]](diffhunk://#diff-ac51f3aae7361690bc98bca02d0799a87d25f9fd0c7481ba868b6c363024d921L173-R173)

**User Interface Enhancements:**
- Added a "Forgot password?" `TextButton` to the login screen, which opens the appropriate environment's password reset page in the browser.
- Adjusted the vertical spacing in the `UserInfoComponent` for a more compact layout.

**Versioning:**
- Bumped the app version name to `1.2.6` and version code to `15` in `build.gradle.kts`.
[Screen_recording_20260701_150410.webm](https://github.com/user-attachments/assets/75f39ee9-7ed9-4fb9-8aae-8077f646dcf1)
