### PR TITLE
Add content description to title in LongFormAdapter for accessibility

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk_long_form/data/LongFormAdapter.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk_long_form/data/LongFormAdapter.kt
@@ -348,6 +348,11 @@ class LongFormAdapter<T>(val cameraIntent: () -> Unit) :
         fun bind(item: LongFormQuest, position: Int) {
 
             binding.title.text = item.questTitle
+            binding.title.contentDescription = if (allowMultiChoice) {
+                "${item.questTitle}. Multiple items can be selected"
+            } else {
+                "${item.questTitle}. Only one item can be selected"
+            }
             if (!item.questImageUrl.isNullOrBlank() && !preferences.isLowBandwidthModeEnabled) {
                 binding.imageView.setImage(
                     ImageUrl(item.questImageUrl),


### PR DESCRIPTION
This pull request introduces an accessibility improvement to the `LongFormAdapter` by updating the `contentDescription` of the `title` view. The new description now informs users whether multiple items or only one item can be selected, enhancing the experience for users relying on screen readers.

Accessibility improvements:

* [`LongFormAdapter.kt`](diffhunk://#diff-6ace3085a0f3a6c98c9e996716429a5cbed63fc503ed17c3f9014c7d13f7a721R351-R355): Sets the `contentDescription` of `binding.title` to indicate whether multiple or single selection is allowed, based on the `allowMultiChoice` flag.
[Screen_recording_20260702_155221.webm](https://github.com/user-attachments/assets/a634d68c-2fe2-49e9-99bb-86e298f3ef86)
