### PR TITLE
Enhance MainMenuDialog by adding descriptive text for button actions 

### DIFF
--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/MainMenuDialog.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/MainMenuDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material.icons.outlined.Download
@@ -94,7 +95,8 @@ fun MainMenuDialog(
                                 contentDescription = null
                             )
                         },
-                        text = stringResource(Res.string.action_download),
+                        text = "Fetch map data",
+                        description = "Fetch the latest quests from the server for this area"
                     )
                     HorizontalDivider(
                         modifier = Modifier
@@ -168,6 +170,7 @@ private fun CompactMenuButton(
     icon: @Composable () -> Unit,
     text: String,
     modifier: Modifier = Modifier,
+    description: String = "",
     enabled: Boolean = true,
     colors: ButtonColors = ButtonDefaults.buttonColors(
         containerColor = MaterialTheme.colorScheme.surface,
@@ -184,12 +187,22 @@ private fun CompactMenuButton(
             verticalAlignment = Alignment.CenterVertically
         ) {
             icon()
-            Text(
-                text = text,
-                modifier = Modifier.weight(1f).padding(horizontal = 16.dp),
-                textAlign = TextAlign.Start,
-                style = MaterialTheme.typography.bodyLarge,
-            )
+            Column {
+                Text(
+                    text = text,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    textAlign = TextAlign.Start,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                if (description.isNotEmpty()){
+                    Text(
+                        text = description,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        textAlign = TextAlign.Start,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request updates the `MainMenuDialog` in the Compose UI to improve the clarity and accessibility of menu buttons, particularly by adding support for button descriptions and updating button text. The changes enhance both the user experience and code flexibility.

**UI/UX Improvements:**

* The "Download" button text is updated to "Fetch map data", and a descriptive subtitle ("Fetch the latest quests from the server for this area") is added to clarify its function for users.
* The `CompactMenuButton` component is enhanced to accept an optional `description` parameter and display it beneath the main button text if provided, improving accessibility and context for menu actions. [[1]](diffhunk://#diff-3b93fc42f3f26a418f9d8d12304acdc858d9ff3e431e8c294b13e9428ca99b44R173) [[2]](diffhunk://#diff-3b93fc42f3f26a418f9d8d12304acdc858d9ff3e431e8c294b13e9428ca99b44R190-R205)

**Codebase Enhancements:**

* Added the `wrapContentSize` import to support more flexible layout options, preparing for potential future layout adjustments.