### PR TITLE
Bugfixes schema3.2.0

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/data/workspace/data/remote/WorkspaceApiService.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/data/workspace/data/remote/WorkspaceApiService.kt
@@ -196,6 +196,7 @@ class WorkspaceApiService(
                 method = HttpMethod.Get
             ) {
                 post(url) {
+                    workspaceConfigProvider.workspaceToken?.let { bearerAuth(it) }
                     setBody(refreshToken)
                     contentType(ContentType.Application.Json)
                 }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/create_feature/FeaturePresetCatalog.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/create_feature/FeaturePresetCatalog.kt
@@ -3,6 +3,8 @@ package de.westnordost.streetcomplete.quests.create_feature
 import de.westnordost.streetcomplete.data.edithistory.Edit
 import de.westnordost.streetcomplete.data.osm.edits.ElementEdit
 import de.westnordost.streetcomplete.data.osm.edits.create.CreateNodeAction
+import de.westnordost.streetcomplete.data.quest.QuestType
+import de.westnordost.streetcomplete.quests.sidewalk_long_form.AddGenericLong
 import de.westnordost.streetcomplete.quests.sidewalk_long_form.data.CustomIcon
 import de.westnordost.streetcomplete.quests.sidewalk_long_form.data.FeaturePreset
 import de.westnordost.streetcomplete.view.presetIconIndex
@@ -33,6 +35,9 @@ class FeaturePresetCatalog {
     fun findCustomIconUrl(iconName: String): String? =
         customIcons.firstOrNull { it.name == iconName && it.type == "feature-preset" }?.url
 
+    fun findQuestIconUrl(iconName: String): String? =
+        customIcons.firstOrNull { it.name == iconName && it.type == "quest" }?.url
+
     /** Built-in drawable of the preset matching [tags], or null. The schema uses drawable-style
      *  icon names ("preset_temaki_bench"), presetIconIndex iD-style names ("temaki-bench") -
      *  accept both. */
@@ -61,6 +66,25 @@ fun FeaturePresetCatalog.featurePresetCustomIconFileOf(edit: Edit, iconCache: Cu
     if (findPresetIconResId(action.tags) != null) return null // built-in icon takes precedence
     val iconName = findPresetFor(action.tags)?.icon ?: return null
     val url = findCustomIconUrl(iconName) ?: return null
+    return iconCache.getCached(url)
+}
+
+/** For a long-form quest (element type) whose element_type_icon is a URL-based custom icon and
+ *  isn't a built-in drawable: the icon's cached file (downloading it first if needed - quests have
+ *  no picker step to have triggered a download earlier, unlike feature presets), or null. */
+suspend fun FeaturePresetCatalog.questCustomIconFileOrNull(questType: QuestType, iconCache: CustomIconCache): File? {
+    val iconName = (questType as? AddGenericLong)?.unresolvedIconName ?: return null
+    val url = findQuestIconUrl(iconName) ?: return null
+    return iconCache.getOrDownload(url)
+}
+
+/** Same as [questCustomIconFileOrNull] but never triggers a download - only returns the file if
+ *  already cached. Safe to call from non-suspend contexts (e.g. the multi-select long-press
+ *  highlight); the quest's base pin normally already triggered caching via
+ *  [questCustomIconFileOrNull] by the time this is needed. */
+fun FeaturePresetCatalog.cachedQuestCustomIconFileOf(questType: QuestType, iconCache: CustomIconCache): File? {
+    val iconName = (questType as? AddGenericLong)?.unresolvedIconName ?: return null
+    val url = findQuestIconUrl(iconName) ?: return null
     return iconCache.getCached(url)
 }
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk_long_form/AddGenericLong.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/sidewalk_long_form/AddGenericLong.kt
@@ -29,6 +29,14 @@ class AddGenericLong(val item: Elements) :
     val resources: Resources = getKoin().get()
     override val changesetComment = "Changes to ${item.elementType}"
     override val wikiLink = "Key:${item.elementType?.lowercase()}"
+    private val localIconResId: Int? = item.elementTypeIcon?.let { name ->
+        resources.getIdentifier(
+            "ic_quest_$name",
+            "drawable",
+            resources.getResourcePackageName(R.drawable.ic_quest_notes)
+        ).takeIf { it != 0 }
+    }
+
     override val icon = when (item.elementTypeIcon) {
         null -> when(item.elementType?.lowercase()){
             "kerb" -> R.drawable.ic_quest_kerb_type
@@ -36,16 +44,14 @@ class AddGenericLong(val item: Elements) :
             "sidewalks" -> R.drawable.ic_quest_sidewalk
             else -> R.drawable.ic_quest_notes
         }
-        else -> {
-            val iconResId = resources.getIdentifier(
-                "ic_quest_${item.elementTypeIcon}",
-                "drawable",
-                resources.getResourcePackageName(R.drawable.ic_quest_notes)
-            )
-            if (iconResId != 0) iconResId
-            else  R.drawable.ic_quest_notes // Fallback to default icon if not found
-        }
+        else -> localIconResId ?: R.drawable.ic_quest_notes // Fallback to default icon if not found
     }
+
+    // non-null only when element_type_icon is set but didn't resolve to a local ic_quest_*
+    // drawable - lets map-pin code check the workspace's custom-icons list (type="quest") for a
+    // URL override, see FeaturePresetCatalog.questCustomIconFileOrNull
+    val unresolvedIconName: String? =
+        if (item.elementTypeIcon != null && localIconResId == null) item.elementTypeIcon else null
     override val achievements = listOf(PEDESTRIAN)
 
     override val name: String

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
@@ -114,8 +114,10 @@ import de.westnordost.streetcomplete.data.osm.edits.create_feature.CreateFeature
 import de.westnordost.streetcomplete.quests.create_feature.CustomIconCache
 import de.westnordost.streetcomplete.quests.create_feature.FeaturePresetCatalog
 import de.westnordost.streetcomplete.quests.create_feature.customPinIconName
+import de.westnordost.streetcomplete.quests.create_feature.cachedQuestCustomIconFileOf
 import de.westnordost.streetcomplete.quests.create_feature.featurePresetCustomIconFileOf
 import de.westnordost.streetcomplete.quests.create_feature.featurePresetIconOf
+import de.westnordost.streetcomplete.quests.create_feature.questCustomIconFileOrNull
 import de.westnordost.streetcomplete.quests.sidewalk_long_form.AddGenericLong
 import de.westnordost.streetcomplete.quests.sidewalk_long_form.data.CustomIcon
 import de.westnordost.streetcomplete.quests.sidewalk_long_form.data.Elements
@@ -697,7 +699,12 @@ class MainActivity :
         }
         multiSelectViewModel.dynamicText.postValue(getFragmentTitle(quest))
 
-        mapFragment.highlightForMultiSelect(quest.type.icon, quest.type.name, multiSelectPoints)
+        val customIconFile = featurePresetCatalog.cachedQuestCustomIconFileOf(quest.type, customIconCache)
+        if (customIconFile != null) {
+            mapFragment.highlightForMultiSelect(customIconFile, quest.type.name, multiSelectPoints)
+        } else {
+            mapFragment.highlightForMultiSelect(quest.type.icon, quest.type.name, multiSelectPoints)
+        }
     }
 
     private fun getFragmentTitle(quest: Quest?): String? {
@@ -1535,7 +1542,13 @@ class MainActivity :
 
         mapFragment.startFocus(quest.geometry, getQuestFormInsets())
         mapFragment.highlightGeometry(quest.geometry)
-        mapFragment.highlightPins(quest.type.icon, quest.markerLocations)
+        val questCustomIconFile = featurePresetCatalog.questCustomIconFileOrNull(quest.type, customIconCache)
+        if (questCustomIconFile != null) {
+            // already registered as a style image by QuestPinsManager when the base pin was shown
+            mapFragment.highlightPins(customPinIconName(questCustomIconFile), quest.markerLocations)
+        } else {
+            mapFragment.highlightPins(quest.type.icon, quest.markerLocations)
+        }
         mapFragment.hideNonHighlightedPins(quest.key)
         mapFragment.hideOverlay()
     }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/CreateFeatureFragment.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/CreateFeatureFragment.kt
@@ -233,7 +233,9 @@ class CreateFeatureFragment : AbstractBottomSheetFragment() {
         super.onClickClose { listener?.closeCreateFeature() }
     }
 
-    override fun isRejectingClose() = attachPhotoFragment?.imagePaths?.isNotEmpty() == true
+    override fun isRejectingClose() =
+        attachPhotoFragment?.imagePaths?.isNotEmpty() == true ||
+            contentBinding.notesInput.text.isNotBlank()
 
     override fun onDiscard() {
         super.onDiscard()
@@ -258,6 +260,8 @@ class CreateFeatureFragment : AbstractBottomSheetFragment() {
 
         val position = listener?.getMapPositionAt(screenPos.toPointF()) ?: return
         val imagePaths = attachPhotoFragment?.imagePaths.orEmpty()
+        val notes = contentBinding.notesInput.text.toString().trim()
+        val tags = if (notes.isNotEmpty()) preset.tags + ("ext:notes" to notes) else preset.tags
 
         isSubmitting = true
         binding.markerCreateLayout.markerLayoutContainer.visibility = View.INVISIBLE
@@ -268,7 +272,7 @@ class CreateFeatureFragment : AbstractBottomSheetFragment() {
                     AddFeaturePreset,
                     ElementPointGeometry(position),
                     "survey",
-                    CreateNodeAction(position, preset.tags),
+                    CreateNodeAction(position, tags),
                     isNearUserLocation = true
                 )
                 // photos are NOT deleted here - they live on disk until the edit syncs, at which

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/CreateFeatureFragment.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/CreateFeatureFragment.kt
@@ -66,6 +66,7 @@ class CreateFeatureFragment : AbstractBottomSheetFragment() {
     override val bottomSheetTitle get() = bottomSheetBinding.speechBubbleTitleContainer
     override val bottomSheetContent get() = bottomSheetBinding.speechbubbleContentContainer
     override val floatingBottomView: View? get() = null
+    override val defaultExpanded = false
 
     private val contentBinding by viewBinding(FormCreateFeatureBinding::bind, R.id.content)
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.FrameLayout
 import androidx.annotation.DrawableRes
+import java.io.File
 import androidx.annotation.UiThread
 import androidx.core.content.getSystemService
 import androidx.core.graphics.Insets
@@ -306,7 +307,9 @@ class MainMapFragment : MapFragment(), ShowsGeometryMarkers {
             questTypeRegistry,
             visibleQuestsSource,
             this,
-            prefs
+            prefs,
+            featurePresetCatalog,
+            customIconCache
         )
         questPinsManager!!.isVisible = pinMode == PinMode.QUESTS
         viewLifecycleOwner.lifecycle.addObserver(questPinsManager!!)
@@ -578,13 +581,33 @@ class MainMapFragment : MapFragment(), ShowsGeometryMarkers {
     ) {
         viewLifecycleScope.launch(Dispatchers.Default) {
             multiSelectPinMapComponent?.set(iconResId, pinPositions)
-            if (pinPositions.isEmpty()) {
-                questPinsManager?.multiSelectQuestType = null
-                questPinsManager?.onNewScreenPosition()
-            } else if (pinPositions.size == 1) {
-                questPinsManager?.multiSelectQuestType = title
-                questPinsManager?.onNewScreenPosition(true)
-            }
+            onMultiSelectPinsUpdated(title, pinPositions)
+        }
+    }
+
+    /** Like [highlightForMultiSelect], but with an already-cached custom icon file (e.g. a
+     *  workspace's URL-based quest icon) */
+    fun highlightForMultiSelect(
+        iconFile: File,
+        title: String,
+        pinPositions: Collection<Pair<LatLon, Map<String, String>>>,
+    ) {
+        viewLifecycleScope.launch(Dispatchers.Default) {
+            multiSelectPinMapComponent?.set(iconFile, pinPositions)
+            onMultiSelectPinsUpdated(title, pinPositions)
+        }
+    }
+
+    private fun onMultiSelectPinsUpdated(
+        title: String,
+        pinPositions: Collection<Pair<LatLon, Map<String, String>>>,
+    ) {
+        if (pinPositions.isEmpty()) {
+            questPinsManager?.multiSelectQuestType = null
+            questPinsManager?.onNewScreenPosition()
+        } else if (pinPositions.size == 1) {
+            questPinsManager?.multiSelectQuestType = title
+            questPinsManager?.onNewScreenPosition(true)
         }
     }
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/QuestPinsManager.kt
@@ -18,6 +18,10 @@ import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.data.quest.VisibleQuestsSource
 import de.westnordost.streetcomplete.data.visiblequests.QuestTypeOrderSource
+import de.westnordost.streetcomplete.quests.create_feature.CustomIconCache
+import de.westnordost.streetcomplete.quests.create_feature.FeaturePresetCatalog
+import de.westnordost.streetcomplete.quests.create_feature.customPinIconName
+import de.westnordost.streetcomplete.quests.create_feature.questCustomIconFileOrNull
 import de.westnordost.streetcomplete.screens.main.map.components.MultiSelectPinMapComponent
 import de.westnordost.streetcomplete.screens.main.map.components.Pin
 import de.westnordost.streetcomplete.screens.main.map.components.PinsMapComponent
@@ -52,6 +56,8 @@ class QuestPinsManager(
     private val visibleQuestsSource: VisibleQuestsSource,
     private val mapFragment: MainMapFragment,
     private val preferences: Preferences,
+    private val featurePresetCatalog: FeaturePresetCatalog,
+    private val customIconCache: CustomIconCache,
 ) : DefaultLifecycleObserver {
     private val overlayPositions: MutableList<Pair<Float, Float>> = mutableListOf()
 
@@ -272,11 +278,19 @@ class QuestPinsManager(
         }
     }
 
-    private fun createQuestPins(quest: Quest): List<Pin> {
+    private suspend fun createQuestPins(quest: Quest): List<Pin> {
         val props = quest.key.toProperties()
         val order = questTypeOrdersLock.withLock { questTypeOrders[quest.type] ?: 0 }
         val isEnabled = multiSelectQuestType?.let { quest.type.name == it } ?: true
-        return quest.markerLocations.map { Pin(it, quest.type.icon, props, order, isEnabled) }
+        // workspace-configured custom icon (element_type_icon) for quest types with no matching
+        // local ic_quest_* drawable - falls back to the built-in resource id when absent/uncached
+        val customIconFile = featurePresetCatalog.questCustomIconFileOrNull(quest.type, customIconCache)
+        val customIconName = customIconFile
+            ?.let { customPinIconName(it) }
+            ?.takeIf { pinsMapComponent.addCustomPinIcon(it, customIconFile) }
+        return quest.markerLocations.map {
+            Pin(it, quest.type.icon, props, order, isEnabled, iconImageName = customIconName)
+        }
     }
 
     private fun reinitializeQuestTypeOrders() {

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/components/MultiSelectPinMapComponent.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/components/MultiSelectPinMapComponent.kt
@@ -1,12 +1,15 @@
 package de.westnordost.streetcomplete.screens.main.map.components
 
 import android.content.Context
+import android.graphics.BitmapFactory
+import android.graphics.drawable.BitmapDrawable
 import androidx.annotation.DrawableRes
 import androidx.annotation.UiThread
 import androidx.lifecycle.DefaultLifecycleObserver
 import com.google.gson.JsonObject
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.quests.create_feature.customPinIconName
 import de.westnordost.streetcomplete.screens.main.map.createPinBitmap
 import de.westnordost.streetcomplete.screens.main.map.maplibre.MapImages
 import de.westnordost.streetcomplete.screens.main.map.maplibre.clear
@@ -15,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.maps.MapLibreMap
+import java.io.File
 import org.maplibre.android.style.expressions.Expression.get
 import org.maplibre.android.style.layers.Layer
 import org.maplibre.android.style.layers.PropertyFactory.iconAllowOverlap
@@ -39,6 +43,7 @@ class MultiSelectPinMapComponent(
 ) : DefaultLifecycleObserver {
 
     private val selectedPinsSource = GeoJsonSource("multi-selected-pins-source")
+    private val customPinIconNames = HashSet<String>()
 
     val layers: List<Layer> = listOf(
         SymbolLayer("multi-selected-pins-layer", "multi-selected-pins-source")
@@ -79,6 +84,37 @@ class MultiSelectPinMapComponent(
                 R.drawable.checkbox
             ) to false
         }
+        showPins(iconName, pinPositions)
+    }
+
+    /** Like [set], but with an already-cached custom icon file (e.g. a workspace's URL-based
+     *  quest icon) instead of a drawable resource - combined with the checkbox tick mark the
+     *  same way as the resId version. */
+    suspend fun set(
+        iconFile: File,
+        pinPositions: Collection<Pair<LatLon, Map<String, String>>>,
+    ) {
+        val combinedName = "pin_with_tick_" + customPinIconName(iconFile)
+        if (combinedName !in customPinIconNames) {
+            val iconBitmap = withContext(Dispatchers.IO) { BitmapFactory.decodeFile(iconFile.path) }
+            if (iconBitmap != null) {
+                val pinBitmap = createPinBitmap(
+                    context,
+                    icon = BitmapDrawable(context.resources, iconBitmap),
+                    insetIcon = true, // custom icon files are full-bleed, like the preset_* glyphs
+                    tickMarkResId = R.drawable.checkbox
+                )
+                withContext(Dispatchers.Main) { map.style?.addImage(combinedName, pinBitmap) }
+                customPinIconNames.add(combinedName)
+            }
+        }
+        showPins(combinedName, pinPositions)
+    }
+
+    private suspend fun showPins(
+        iconName: String,
+        pinPositions: Collection<Pair<LatLon, Map<String, String>>>,
+    ) {
         val points = pinPositions.map { (latLon, properties) ->
             val p = JsonObject()
             properties.forEach { (key, value) ->

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkSpaceActivity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkSpaceActivity.kt
@@ -280,18 +280,28 @@ fun AppNavigator(
             // without this, a failed refresh here left the user stranded on this screen with a
             // stale token and no path back to login until some other request happened to 401
             val loginState by viewModel.loginState.collectAsState()
+            // while a proactive refresh is in flight, the location-triggered fetch below must
+            // wait for it - otherwise it races refreshToken() and calls project-group-roles/
+            // getWorkspaces with the still-stale (possibly already-expired) token, hitting a 401
+            // even though the refresh may still succeed a moment later
+            var tokenRefreshInFlight by remember { mutableStateOf(doTokenRefresh) }
             LaunchedEffect(loginState) {
-                if (loginState is WorkspaceLoginState.Error) {
-                    preferences.workspaceLogin = false
-                    val intent = Intent(context, WorkSpaceActivity::class.java).apply {
-                        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                        putExtra(WorkSpaceActivity.SHOW_LOGGED_OUT_ALERT, true)
+                when (loginState) {
+                    is WorkspaceLoginState.Error -> {
+                        preferences.workspaceLogin = false
+                        val intent = Intent(context, WorkSpaceActivity::class.java).apply {
+                            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                            putExtra(WorkSpaceActivity.SHOW_LOGGED_OUT_ALERT, true)
+                        }
+                        context.startActivity(intent)
                     }
-                    context.startActivity(intent)
+                    is WorkspaceLoginState.Success -> tokenRefreshInFlight = false
+                    else -> {}
                 }
             }
 
-            LaunchedEffect(Unit) {
+            LaunchedEffect(tokenRefreshInFlight) {
+                if (tokenRefreshInFlight) return@LaunchedEffect
                 if (ActivityCompat.checkSelfPermission(
                         context,
                         Manifest.permission.ACCESS_FINE_LOCATION

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkspaceViewModel.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkspaceViewModel.kt
@@ -232,6 +232,14 @@ class WorkspaceViewModelImpl(
     // debug-only: lets test-data JSON be edited on-device (`adb push` to testLongFormJsonFile's
     // path, no rebuild needed) instead of only via the hardcoded DEFAULT_TEST_LONG_FORM_JSON.
     // Falls back to the default on any read/parse problem so a bad edit can't crash the flow.
+    //
+    // adb push command (path = getExternalFilesDir(null), applicationId has no debug suffix):
+    //   adb shell mkdir -p /storage/emulated/0/Android/data/net.opentoall.aviv.scoutroute/files
+    //   adb push test_workspace_longform.json \
+    //     /storage/emulated/0/Android/data/net.opentoall.aviv.scoutroute/files/test_workspace_longform.json
+    // The mkdir step is required if the app was just installed/reinstalled and hasn't launched
+    // yet - getExternalFilesDir() normally creates that directory lazily on first app launch, so
+    // pushing before the first launch would otherwise fail with "No such file or directory".
     private fun readTestLongFormJson(): String {
         if (!BuildConfig.DEBUG || !testLongFormJsonFile.exists()) return DEFAULT_TEST_LONG_FORM_JSON
         return try {

--- a/app/src/androidMain/res/layout/form_create_feature.xml
+++ b/app/src/androidMain/res/layout/form_create_feature.xml
@@ -62,12 +62,17 @@
 
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/addPhotosLabel"
+        <EditText
+            android:id="@+id/notesInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
-            android:text="@string/create_feature_add_photos"/>
+            android:inputType="textMultiLine|textCapSentences"
+            android:gravity="top|start"
+            android:minLines="3"
+            android:maxLength="255"
+            android:hint="@string/add_feature_notes_hint"
+            android:background="@drawable/background_edittext_outline"/>
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/attachPhotoFragment"

--- a/app/src/androidMain/res/values/strings.xml
+++ b/app/src/androidMain/res/values/strings.xml
@@ -1864,13 +1864,13 @@ Alternatively, you can leave a note (with a photo).</string>
     <string name="profile_icon">Navigate to profile screen</string>
     <string name="workspace">Workspace</string>
     <string name="enter_text">Enter text</string>
+    <string name="add_feature_notes_hint">Add a note (optional)</string>
 
     <string name="close_image">Close image</string>
     <string name="confirmation_hide_quest">"Are you sure you want to hide this quest?"</string>
     <string name="confirmation_hide_quest_yes">"Yes"</string>
     <string name="map_btn_create_node">Add new feature</string>
     <string name="create_feature_new_title">New feature: %s</string>
-    <string name="create_feature_add_photos">Add photos of this feature (optional)</string>
     <string name="create_feature_confirm">Add feature</string>
 
     <string name="follow_mode">Screen Reader Mode</string>


### PR DESCRIPTION
This pull request introduces support for using workspace-configured custom quest icons (from URLs) for long-form quests, ensuring that both the main quest pins and multi-select highlights display these icons when configured. It also improves the feature creation bottom sheet by preventing accidental closure when notes are entered and ensures that notes are included as tags when creating a new feature. Several internal refactorings were made to support these features, including updates to icon handling and caching.

**Custom Quest Icon Support**

* Added logic to `AddGenericLong` and `FeaturePresetCatalog` to allow quests to specify a custom icon via URL if no local drawable is available, including caching and retrieval mechanisms. [[1]](diffhunk://#diff-b37cd17a42e13be542557a9884462dfff5f214a478cfd71898961f3f0787eb0bR32-R54) [[2]](diffhunk://#diff-a44bd39d4d0ead9da224bf9b8cf400dd1786ffe0bdb623e0af0be0398a0ad626R38-R40) [[3]](diffhunk://#diff-a44bd39d4d0ead9da224bf9b8cf400dd1786ffe0bdb623e0af0be0398a0ad626R72-R90)
* Updated `QuestPinsManager`, `MainMapFragment`, and `MultiSelectPinMapComponent` to display workspace custom icons for quest pins and multi-select highlights, using cached files and proper image registration with the map. [[1]](diffhunk://#diff-58dcbe36023088600d3f5d2b1fe8d00e0edf46cbffee1b8e13af4234be3ab40eR59-R60) [[2]](diffhunk://#diff-58dcbe36023088600d3f5d2b1fe8d00e0edf46cbffee1b8e13af4234be3ab40eL275-R293) [[3]](diffhunk://#diff-5646c8ede74a669b83b6bd62a8abcc2fce17357c7d61945b545e36a3b17e572cL309-R312) [[4]](diffhunk://#diff-5646c8ede74a669b83b6bd62a8abcc2fce17357c7d61945b545e36a3b17e572cR584-R604) [[5]](diffhunk://#diff-3c5256185b8c0b7dac8f2520d864f4ffc276c9bed79c134a1e221776f354b444R4-R12) [[6]](diffhunk://#diff-3c5256185b8c0b7dac8f2520d864f4ffc276c9bed79c134a1e221776f354b444R87-R117)

**Feature Creation Improvements**

* Modified `CreateFeatureFragment` to prevent closing the bottom sheet if the user has entered notes, and to include notes as an `ext:notes` tag when creating a new feature. [[1]](diffhunk://#diff-0cc6935682becab06eea35cb3da0f262c0083acc8dbe5856fa80809269277b7aL235-R238) [[2]](diffhunk://#diff-0cc6935682becab06eea35cb3da0f262c0083acc8dbe5856fa80809269277b7aR263-R264) [[3]](diffhunk://#diff-0cc6935682becab06eea35cb3da0f262c0083acc8dbe5856fa80809269277b7aL270-R275)

**Other Enhancements**

* Ensured that authentication is used for workspace API calls by adding the workspace token to requests.
* Set the default state of the create feature bottom sheet to collapsed.

These changes collectively improve the user experience for custom workspace quests and make the feature creation process more robust.