### PR TITLE
Bugfix refresh token

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
@@ -1,5 +1,6 @@
 package de.westnordost.streetcomplete
 
+import android.content.Context
 import android.content.Intent
 import android.content.res.AssetManager
 import android.content.res.Resources
@@ -18,6 +19,7 @@ import de.westnordost.streetcomplete.util.logs.DatabaseLogger
 import de.westnordost.streetcomplete.util.logs.Log
 import de.westnordost.streetcomplete.util.satellite_layers.ImageryRepository
 import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
@@ -44,6 +46,61 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
+// shared by every HttpClient that calls OSM/workspace endpoints with the workspace bearer token
+// (the main workspace-API client and osmClient/MapDataApiClient/ChangesetApiClient/NotesApiClient)
+// - extracted so the reactive 401-triggered refresh-and-retry behavior can't drift between them
+// the way it did when only the main client had it: osmClient previously had no Auth plugin at
+// all, so any expired access token on a map-data/changeset/note call skipped straight to
+// AuthorizationException -> Downloader/Uploader's unconditional userLoginController.logOut(),
+// with no refresh attempt first.
+private fun HttpClientConfig<*>.installWorkspaceBearerAuth(
+    context: Context,
+    preferences: Preferences,
+    environmentManager: EnvironmentManager,
+) {
+    install(Auth) {
+        bearer {
+            loadTokens {
+                val token = preferences.workspaceToken
+                val refreshToken = preferences.workspaceRefreshToken
+                if (token != null && refreshToken != null) {
+                    BearerTokens(token, refreshToken)
+                } else {
+                    null
+                }
+            }
+
+            sendWithoutRequest { request ->
+                val url = request.url.toString()
+                !url.contains("raw.githubusercontent.com") &&
+                    !url.contains("githubusercontent.com") && !url.contains("refresh-token")
+            }
+
+            refreshTokens {
+                if (!preferences.workspaceLogin)
+                    return@refreshTokens null
+                val newAccessToken =
+                    refreshJwtToken(preferences, environmentManager)
+
+                if (newAccessToken == null) {
+                    preferences.workspaceLogin = false
+                    //Launch workspaceActivity
+                    val intent = Intent(context, WorkSpaceActivity::class.java)
+                    intent.flags =
+                        Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                    intent.putExtra(SHOW_LOGGED_OUT_ALERT, true)
+                    context.startActivity(intent)
+                }
+
+                newAccessToken?.let {
+                    preferences.workspaceToken = it  // Save new access token
+                    BearerTokens(it, preferences.workspaceRefreshToken!!)
+                }
+            }
+        }
+    }
+}
+
 val appModule = module {
     factory<AssetManager> { androidContext().assets }
     factory<Resources> { androidContext().resources }
@@ -53,6 +110,9 @@ val appModule = module {
     single { SoundFx(androidContext()) }
     single { Json { ignoreUnknownKeys = true } }
     single(named("osmClient")) {
+        val context = androidContext()
+        val preferences = get<Preferences>()
+        val environmentManager = get<EnvironmentManager>()
         HttpClient {
             defaultRequest {
                 userAgent(ApplicationConstants.USER_AGENT)
@@ -60,9 +120,13 @@ val appModule = module {
             install(ContentEncoding) {
                 gzip()
             }
+            installWorkspaceBearerAuth(context, preferences, environmentManager)
         }
     }
     single {
+        val context = androidContext()
+        val preferences = get<Preferences>()
+        val environmentManager = get<EnvironmentManager>()
         HttpClient {
             install(ContentNegotiation) {
                 json(Json {
@@ -73,51 +137,7 @@ val appModule = module {
             install(ContentEncoding) {
                 gzip()
             }
-            install(Auth) {
-                bearer {
-                    loadTokens {
-                        val token = get<Preferences>().workspaceToken
-                        val refreshToken = get<Preferences>().workspaceRefreshToken
-                        if (token != null && refreshToken != null) {
-                            BearerTokens(token, refreshToken)
-                        } else {
-                            null
-                        }
-                    }
-
-                    sendWithoutRequest { request ->
-                        val url = request.url.toString()
-                        !url.contains("raw.githubusercontent.com") &&
-                            !url.contains("githubusercontent.com") && !url.contains("refresh-token")
-                    }
-
-                    refreshTokens {
-                        val preferences = get<Preferences>()
-                        val httpClient = get<HttpClient>() // Inject HttpClient for making requests
-                        val environmentManager = get<EnvironmentManager>()
-
-                        if (!preferences.workspaceLogin)
-                            return@refreshTokens null
-                        val newAccessToken =
-                            refreshJwtToken(preferences, environmentManager)
-
-                        if (newAccessToken == null) {
-                            preferences.workspaceLogin = false
-                            //Launch workspaceActivity
-                            val intent = Intent(androidContext(), WorkSpaceActivity::class.java)
-                            intent.flags =
-                                Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                            intent.putExtra(SHOW_LOGGED_OUT_ALERT, true)
-                            androidContext().startActivity(intent)
-                        }
-
-                        newAccessToken?.let {
-                            preferences.workspaceToken = it  // Save new access token
-                            BearerTokens(it, preferences.workspaceRefreshToken!!)
-                        }
-                    }
-                }
-            }
+            installWorkspaceBearerAuth(context, preferences, environmentManager)
             install(Logging) {
                 logger = object : Logger {
                     override fun log(message: String) {
@@ -184,6 +204,16 @@ suspend fun refreshJwtToken(
             preferences.refreshTokenExpiryInterval = jsonResponse.refresh_expires_in * 1000
             preferences.accessTokenExpiryInterval = jsonResponse.expires_in * 1000
             preferences.workspaceLastLogin = System.currentTimeMillis()
+            // must stay in sync with the other two refresh/login call sites
+            // (WorkspaceViewModel.refreshToken()/setLoginState()) - this is the reactive
+            // Ktor Auth 401-triggered refresh path, and without recomputing these two absolute
+            // timestamps here, WorkSpaceActivity's stale-refresh-token check keeps counting down
+            // from whenever the last proactive refresh/login happened, even though this path just
+            // rotated the refresh token and kept the session alive.
+            preferences.refreshTokenExpiryTime =
+                preferences.workspaceLastLogin + preferences.refreshTokenExpiryInterval
+            preferences.accessTokenExpiryTime =
+                preferences.workspaceLastLogin + preferences.accessTokenExpiryInterval
 
             jsonResponse.access_token
         } else null

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
@@ -17,6 +17,7 @@ import de.westnordost.streetcomplete.util.ResourceProvider
 import de.westnordost.streetcomplete.util.SoundFx
 import de.westnordost.streetcomplete.util.logs.DatabaseLogger
 import de.westnordost.streetcomplete.util.logs.Log
+import de.westnordost.streetcomplete.util.network.retryOnTransientHttpFailure
 import de.westnordost.streetcomplete.util.satellite_layers.ImageryRepository
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
@@ -189,12 +190,16 @@ suspend fun refreshJwtToken(
             }
         }
 
-        val response =
+        // a transient failure here (network blip, backend 5xx, rate limit) must not be treated
+        // the same as an actually invalid/expired refresh token - both used to fall through to
+        // the same "refresh failed -> force logout" path below with zero retry.
+        val response = retryOnTransientHttpFailure {
             tempClient.post(environmentManager.currentEnvironment.tdeiBaseUrl + "/refresh-token") {
                 // the API takes the refresh token as the "refresh_token" header, not the body
                 // (confirmed against the API's own curl example) - body must stay empty.
                 header("refresh_token", preferences.workspaceRefreshToken)
             }
+        }
 
         if (response.status == HttpStatusCode.OK) {
             val jsonResponse = Json.decodeFromString<LoginResponse>(response.bodyAsText())

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/data/workspace/data/remote/WorkspaceApiService.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/data/workspace/data/remote/WorkspaceApiService.kt
@@ -11,6 +11,7 @@ import de.westnordost.streetcomplete.data.workspace.domain.model.LoginResponse
 import de.westnordost.streetcomplete.data.workspace.domain.model.UserInfoResponse
 import de.westnordost.streetcomplete.quests.sidewalk_long_form.data.WorkspaceDetailsResponse
 import de.westnordost.streetcomplete.util.firebase.performHttpCallWithFirebaseTracing
+import de.westnordost.streetcomplete.util.network.retryOnTransientHttpFailure
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.auth.authProvider
@@ -191,21 +192,27 @@ class WorkspaceApiService(
         val url = environmentManager.currentEnvironment.tdeiBaseUrl + "/refresh-token"
         try {
 
-            val response = performHttpCallWithFirebaseTracing(
-                client = httpClient,
-                url = url,
-                method = HttpMethod.Get
-            ) {
-                post(url) {
-                    // deliberately no bearerAuth here - this call fires precisely when the access
-                    // token is expired/near-expiry, so attaching it as Authorization risks the
-                    // server rejecting the request before it even looks at the refresh token. The
-                    // reactive refresh path (refreshJwtToken() in ApplicationModule.kt) hits the
-                    // same endpoint the same way, unauthenticated.
-                    //
-                    // the API takes the refresh token as the "refresh_token" header, not the body
-                    // (confirmed against the API's own curl example) - body must stay empty.
-                    header("refresh_token", refreshToken)
+            // a transient failure here (network blip, backend 5xx, rate limit) must not be
+            // treated the same as an actually invalid/expired refresh token - both used to
+            // surface as the same thrown Exception below, which WorkSpaceActivity treats as
+            // fatal (force logout) with zero retry.
+            val response = retryOnTransientHttpFailure {
+                performHttpCallWithFirebaseTracing(
+                    client = httpClient,
+                    url = url,
+                    method = HttpMethod.Get
+                ) {
+                    post(url) {
+                        // deliberately no bearerAuth here - this call fires precisely when the access
+                        // token is expired/near-expiry, so attaching it as Authorization risks the
+                        // server rejecting the request before it even looks at the refresh token. The
+                        // reactive refresh path (refreshJwtToken() in ApplicationModule.kt) hits the
+                        // same endpoint the same way, unauthenticated.
+                        //
+                        // the API takes the refresh token as the "refresh_token" header, not the body
+                        // (confirmed against the API's own curl example) - body must stay empty.
+                        header("refresh_token", refreshToken)
+                    }
                 }
             }
             if (response.status == HttpStatusCode.OK) {

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkSpaceActivity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/workspaces/WorkSpaceActivity.kt
@@ -47,6 +47,7 @@ import androidx.core.app.ActivityCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -182,11 +183,20 @@ class WorkSpaceActivity : AppCompatActivity() {
             contentWindowInsets = WindowInsets.statusBars
         ) { innerPadding ->
             var showDialog by remember { mutableStateOf(showAlert) }
+            val navController = rememberNavController()
 
             MyAlertDialog(
                 showDialog = showDialog,
-                onDismiss = { showDialog = false })
-            AppNavigator(innerPadding, preferences, environmentManager, this)
+                onDismiss = {
+                    showDialog = false
+                    // dismissing "Session Expired" must always land on the login screen, not
+                    // rely on preferences.workspaceLogin already being false and startDestination
+                    // having defaulted to "home" by coincidence of composition order.
+                    navController.navigate("home") {
+                        popUpTo(0) { inclusive = true }
+                    }
+                })
+            AppNavigator(innerPadding, preferences, environmentManager, this, navController)
         }
     }
 
@@ -213,17 +223,20 @@ fun AppNavigator(
     preferences: Preferences,
     environmentManager: EnvironmentManager,
     activity: AppCompatActivity,
+    navController: NavHostController,
     modifier: Modifier = Modifier,
 ) {
-    val navController = rememberNavController()
     var startDestination = "home"
     var doTokenRefresh = false
     var doLogout = false
 
     val data: Uri? = activity.intent?.data
     data?.let {
-        val refreshToken = it.getQueryParameter("code")
-        refreshToken?.isNotBlank().let {
+        val code = it.getQueryParameter("code")
+        // must be ?.let, not .let - refreshToken?.isNotBlank() is a Boolean? that plain .let
+        // would run unconditionally (even when code is null), forcing a logout on any
+        // avivscr:// deep link at all, not just an actual OAuth code redirect.
+        if (!code.isNullOrBlank()) {
             preferences.workspaceLogin = false
             doLogout = true
         }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/util/network/HttpRetry.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/util/network/HttpRetry.kt
@@ -1,0 +1,38 @@
+package de.westnordost.streetcomplete.util.network
+
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+
+private fun HttpResponse.isTransientFailure(): Boolean =
+    status.value in 500..599 || status == HttpStatusCode.TooManyRequests
+
+/**
+ * Runs [block] (a single HTTP call), retrying with exponential backoff (500ms, then 1s) on
+ * failures that are likely transient - network exceptions/timeouts, 5xx, 429 - but not on other
+ * 4xx responses, since those mean the server has definitively rejected the request (e.g. an
+ * actually expired/revoked refresh token) and retrying would just delay the same rejection.
+ */
+suspend fun retryOnTransientHttpFailure(
+    maxAttempts: Int = 3,
+    initialDelayMillis: Long = 500,
+    block: suspend () -> HttpResponse,
+): HttpResponse {
+    var attempt = 1
+    while (true) {
+        val response = try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (attempt >= maxAttempts) throw e
+            delay(initialDelayMillis * (1L shl (attempt - 1)))
+            attempt++
+            continue
+        }
+        if (!response.isTransientFailure() || attempt >= maxAttempts) return response
+        delay(initialDelayMillis * (1L shl (attempt - 1)))
+        attempt++
+    }
+}


### PR DESCRIPTION
This pull request introduces a robust retry mechanism for HTTP calls that are likely to fail transiently (such as network errors, backend 5xx, or rate limiting), and refactors token refresh logic to use this mechanism. It also improves navigation and session handling in the workspace activity, ensuring users are correctly routed to the login screen after session expiry. The changes are grouped as follows:

**Authentication and Token Refresh Improvements:**

* Introduced the `retryOnTransientHttpFailure` utility (`HttpRetry.kt`) to automatically retry HTTP requests on transient failures with exponential backoff, avoiding unnecessary user logouts due to temporary issues.
* Updated both the Ktor Auth plugin's `refreshTokens` handler and `WorkspaceApiService` token refresh logic to wrap refresh requests with `retryOnTransientHttpFailure`, ensuring only truly invalid/expired tokens cause a forced logout. [[1]](diffhunk://#diff-ac51f3aae7361690bc98bca02d0799a87d25f9fd0c7481ba868b6c363024d921L172-R202) [[2]](diffhunk://#diff-299a2dcc24eb36a61d72a3933f6f870077bc04273e97f31c3d72fdcfb70c084cL194-R200)
* Ensured refresh and access token expiry timestamps are recomputed after a successful token refresh in the Auth plugin, keeping session state consistent with other login flows.

**Code Structure and Reuse:**

* Extracted the workspace bearer token authentication logic into a shared `installWorkspaceBearerAuth` function, so all relevant `HttpClient` instances consistently handle token refresh and retry logic. [[1]](diffhunk://#diff-ac51f3aae7361690bc98bca02d0799a87d25f9fd0c7481ba868b6c363024d921L47-R66) [[2]](diffhunk://#diff-ac51f3aae7361690bc98bca02d0799a87d25f9fd0c7481ba868b6c363024d921R103-R141)

**Navigation and Session Handling:**

* Improved session expiry handling in `WorkSpaceActivity`: dismissing the "Session Expired" dialog now always navigates to the login screen, regardless of the current session state.
* Fixed a bug in deep link handling to avoid unintended logouts when the OAuth code is missing, by properly checking for a non-null code parameter.