### PR TITLE
Android UI fixes

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
@@ -44,9 +44,9 @@ import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import androidx.core.view.AccessibilityDelegateCompat
 import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
-import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
@@ -58,12 +58,13 @@ import de.westnordost.osmfeatures.FeatureDictionary
 import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.AllEditTypes
+import de.westnordost.streetcomplete.data.connection.InternetConnectionState
 import de.westnordost.streetcomplete.data.download.tiles.asBoundingBoxOfEnclosingTiles
 import de.westnordost.streetcomplete.data.edithistory.EditHistoryController
 import de.westnordost.streetcomplete.data.edithistory.EditKey
-import de.westnordost.streetcomplete.data.connection.InternetConnectionState
 import de.westnordost.streetcomplete.data.osm.edits.ElementEditType
 import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
+import de.westnordost.streetcomplete.data.osm.edits.create_feature.CreateFeatureRegistry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
@@ -106,15 +107,14 @@ import de.westnordost.streetcomplete.quests.AbstractOsmQuestForm
 import de.westnordost.streetcomplete.quests.AbstractQuestForm
 import de.westnordost.streetcomplete.quests.IsShowingQuestDetails
 import de.westnordost.streetcomplete.quests.LeaveNoteInsteadFragment
-import de.westnordost.streetcomplete.quests.note_discussion.NoteDiscussionForm
-import de.westnordost.streetcomplete.data.osm.edits.create_feature.CreateFeatureRegistry
 import de.westnordost.streetcomplete.quests.create_feature.CustomIconCache
 import de.westnordost.streetcomplete.quests.create_feature.FeaturePresetCatalog
-import de.westnordost.streetcomplete.quests.create_feature.customPinIconName
 import de.westnordost.streetcomplete.quests.create_feature.cachedQuestCustomIconFileOf
+import de.westnordost.streetcomplete.quests.create_feature.customPinIconName
 import de.westnordost.streetcomplete.quests.create_feature.featurePresetCustomIconFileOf
 import de.westnordost.streetcomplete.quests.create_feature.featurePresetIconOf
 import de.westnordost.streetcomplete.quests.create_feature.questCustomIconFileOrNull
+import de.westnordost.streetcomplete.quests.note_discussion.NoteDiscussionForm
 import de.westnordost.streetcomplete.quests.sidewalk_long_form.AddGenericLong
 import de.westnordost.streetcomplete.quests.sidewalk_long_form.data.CustomIcon
 import de.westnordost.streetcomplete.quests.sidewalk_long_form.data.Elements
@@ -356,10 +356,19 @@ class MainActivity :
             startFollowMode()
         }
 
+        binding.toolbar.mainMenuButton.setOnClickListener {
+            viewModel.showFilterOptions()
+        }
+
         binding.toolbar.workspaceContainer.setOnClickListener {
             AlertDialog.Builder(this)
                 .setTitle(R.string.confirmation_switch_workspace_title)
-                .setMessage(getString(R.string.confirmation_switch_workspace_message, viewModel.workspaceTitle.value))
+                .setMessage(
+                    getString(
+                        R.string.confirmation_switch_workspace_message,
+                        viewModel.workspaceTitle.value
+                    )
+                )
                 .setPositiveButton(R.string.confirmation_switch_workspace_confirm) { _, _ ->
                     val intent = Intent(this, WorkSpaceActivity::class.java)
                     startActivity(intent)
@@ -378,10 +387,14 @@ class MainActivity :
                 mapFragment?.startFocus(geometry, Insets.NONE)
                 mapFragment?.highlightGeometry(geometry)
                 // created features show the added feature's own icon inside the pin bubble
-                val customIconFile = featurePresetCatalog.featurePresetCustomIconFileOf(edit, customIconCache)
+                val customIconFile =
+                    featurePresetCatalog.featurePresetCustomIconFileOf(edit, customIconCache)
                 if (customIconFile != null) {
                     // registered as a style image when the edit history pins were shown
-                    mapFragment?.highlightPins(customPinIconName(customIconFile), listOf(edit.position))
+                    mapFragment?.highlightPins(
+                        customPinIconName(customIconFile),
+                        listOf(edit.position)
+                    )
                 } else {
                     val pinIcon = featurePresetCatalog.featurePresetIconOf(edit) ?: edit.icon
                     mapFragment?.highlightPins(pinIcon, listOf(edit.position))
@@ -717,7 +730,8 @@ class MainActivity :
         }
         multiSelectViewModel.dynamicText.postValue(getFragmentTitle(quest))
 
-        val customIconFile = featurePresetCatalog.cachedQuestCustomIconFileOf(quest.type, customIconCache)
+        val customIconFile =
+            featurePresetCatalog.cachedQuestCustomIconFileOf(quest.type, customIconCache)
         if (customIconFile != null) {
             mapFragment.highlightForMultiSelect(customIconFile, quest.type.name, multiSelectPoints)
         } else {
@@ -1533,9 +1547,11 @@ class MainActivity :
         /** Not a gig quest, offline, or the check itself failed - proceed exactly as before
          *  (the caller falls back to its usual local element lookup). */
         data object NotChecked : GigQuestCheckResult
+
         /** Checked and still needs an answer - use this freshly-fetched element to skip a
          *  redundant local lookup, so the form opens with the latest tags. */
         data class StillOpen(val element: Element) : GigQuestCheckResult
+
         /** Checked and someone else already answered it - the "already answered" sheet is
          *  showing; the form must not open. */
         data object AlreadyAnswered : GigQuestCheckResult
@@ -1579,7 +1595,8 @@ class MainActivity :
         }
 
         checkSheet.dismiss()
-        return freshElement?.let { GigQuestCheckResult.StillOpen(it) } ?: GigQuestCheckResult.NotChecked
+        return freshElement?.let { GigQuestCheckResult.StillOpen(it) }
+            ?: GigQuestCheckResult.NotChecked
     }
 
     @UiThread
@@ -1621,7 +1638,8 @@ class MainActivity :
 
         mapFragment.startFocus(quest.geometry, getQuestFormInsets())
         mapFragment.highlightGeometry(quest.geometry)
-        val questCustomIconFile = featurePresetCatalog.questCustomIconFileOrNull(quest.type, customIconCache)
+        val questCustomIconFile =
+            featurePresetCatalog.questCustomIconFileOrNull(quest.type, customIconCache)
         if (questCustomIconFile != null) {
             // already registered as a style image by QuestPinsManager when the base pin was shown
             mapFragment.highlightPins(customPinIconName(questCustomIconFile), quest.markerLocations)
@@ -1786,7 +1804,8 @@ class MainActivity :
                 intent?.getParcelableArrayListExtra<Imagery>("IMAGERY_LIST") ?: emptyList()
             }
             try {
-                imageryPickerList = imageryRepository.getImageryForLocation(screenCenter, imagerList).orEmpty()
+                imageryPickerList =
+                    imageryRepository.getImageryForLocation(screenCenter, imagerList).orEmpty()
             } catch (e: Exception) {
                 Log.d("Error", e.message.toString())
                 Toast.makeText(

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainScreen.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
@@ -69,7 +70,7 @@ import de.westnordost.streetcomplete.screens.main.controls.AttributionButton
 import de.westnordost.streetcomplete.screens.main.controls.AttributionLink
 import de.westnordost.streetcomplete.screens.main.controls.CompassButton
 import de.westnordost.streetcomplete.screens.main.controls.Crosshair
-import de.westnordost.streetcomplete.screens.main.controls.FilterOptionsButton
+import de.westnordost.streetcomplete.screens.main.controls.DownloadMapDataButton
 import de.westnordost.streetcomplete.screens.main.controls.ImageryListButton
 import de.westnordost.streetcomplete.screens.main.controls.LocationState
 import de.westnordost.streetcomplete.screens.main.controls.LocationStateButton
@@ -171,7 +172,6 @@ fun MainScreen(
 
     var showOverlaysDropdown by remember { mutableStateOf(false) }
     var showTeamModeWizard by remember { mutableStateOf(false) }
-    var showFilterOptions by remember { mutableStateOf(false) }
     val showMainMenuDialog by viewModel.showMainMenuDialog.collectAsState()
     var shownMessage by remember { mutableStateOf<Message?>(null) }
     val showEditHistorySidebar by editHistoryViewModel.isShowingSidebar.collectAsState()
@@ -290,33 +290,36 @@ fun MainScreen(
                 // }
 
                 // top-end controls
-                // Row(
-                //     modifier = Modifier
-                //         .align(Alignment.TopEnd)
-                //         .padding(4.dp),
-                //     horizontalArrangement = Arrangement.spacedBy(8.dp)
-                // ) {
-                //     if (overlays.isNotEmpty()) {
-                //         Box {
-                //             OverlaySelectionButton(
-                //                 onClick = ::onClickOverlays,
-                //                 overlay = selectedOverlay
-                //             )
-                //             OverlaySelectionDropdownMenu(
-                //                 expanded = showOverlaysDropdown,
-                //                 onDismissRequest = { showOverlaysDropdown = false },
-                //                 overlays = overlays,
-                //                 onSelect = { viewModel.selectOverlay(it) }
-                //             )
-                //         }
-                //     }
-                //
-                //     MainMenuButton(
-                //         onClick = { showMainMenuDialog = true },
-                //         unsyncedEditsCount = if (!isAutoSync) unsyncedEditsCount else 0,
-                //         indexInTeam = if (isTeamMode) indexInTeam else null
-                //     )
-                // }
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .semantics { isTraversalGroup = true }) {
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(4.dp)
+                                .semantics { isTraversalGroup = true },
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                            horizontalAlignment = Alignment.End,
+                        ) {
+                            ImageryListButton(
+                                onClick = { onClickImageryLayer() }
+                            )
+                            DownloadMapDataButton(
+                                onClick = {
+                                   onClickDownload()
+                                }
+                            )
+                        }
+                    }
+                }
 
                 // bottom controls
                 Column(
@@ -338,14 +341,6 @@ fun MainScreen(
                             verticalArrangement = Arrangement.spacedBy(8.dp),
                             horizontalAlignment = Alignment.End,
                         ) {
-                            ImageryListButton(
-                                onClick = {onClickImageryLayer()}
-                            )
-                            FilterOptionsButton(
-                                onClick = {
-                                    showFilterOptions = true
-                                }
-                            )
                             val isCompassVisible =
                                 mapRotation.absoluteValue >= 1.0 || mapTilt.absoluteValue >= 1.0
                             AnimatedVisibility(
@@ -543,10 +538,10 @@ fun MainScreen(
     lastCrashReport?.let { report ->
         LastCrashEffect(lastReport = report, onReport = { context.sendErrorReportEmail(it) })
     }
-    if (showFilterOptions) {
+    if (viewModel.showFilterOptions.collectAsState().value) {
         QuestSelectionBottomSheet(
             viewModel = koinViewModel(),
-            onClose = { showFilterOptions = false }
+            onClose = { viewModel.showFilterOptions.value = false }
         )
     }
 
@@ -783,8 +778,14 @@ object PreviewMainViewModel : MainViewModel() {
 
     override val showMainMenuDialog: MutableStateFlow<Boolean>
         get() = MutableStateFlow(false)
+    override val showFilterOptions: MutableStateFlow<Boolean>
+        get() = TODO("Not yet implemented")
 
     override fun showMenu() {
+        TODO("Not yet implemented")
+    }
+
+    override fun showFilterOptions() {
         TODO("Not yet implemented")
     }
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainViewModel.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainViewModel.kt
@@ -114,10 +114,12 @@ abstract class MainViewModel : ViewModel() {
     abstract fun addAttributionsToMap(attribution: Attribution?)
     abstract fun hideMenu()
     abstract fun showMenu()
+    abstract fun showFilterOptions()
 
     abstract var workspaceTitle : MutableStateFlow<String>
 
     abstract val showMainMenuDialog : MutableStateFlow<Boolean>
+    abstract val showFilterOptions : MutableStateFlow<Boolean>
 
     abstract val followVisible: MutableStateFlow<Boolean>
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainViewModelImpl.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainViewModelImpl.kt
@@ -475,8 +475,13 @@ class MainViewModelImpl(
     override var workspaceTitle: MutableStateFlow<String> = MutableStateFlow("Workspace")
 
     override val showMainMenuDialog : MutableStateFlow<Boolean> = MutableStateFlow(false)
+    override val showFilterOptions: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     override fun showMenu() { showMainMenuDialog.value = true }
+
+    override fun showFilterOptions() {
+        showFilterOptions.value = true
+    }
     override fun hideMenu() { showMainMenuDialog.value = false }
 
     override val followVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/AbstractBottomSheetFragment.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/bottom_sheet/AbstractBottomSheetFragment.kt
@@ -63,6 +63,7 @@ abstract class AbstractBottomSheetFragment : Fragment(), IsCloseableBottomSheet 
         }
 
         bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
+        bottomSheetBehavior.maxHeight = maxBottomSheetHeightPx()
 
         bottomSheetTitle?.setOnClickListener {
             bottomSheetBehavior.apply {
@@ -96,8 +97,15 @@ abstract class AbstractBottomSheetFragment : Fragment(), IsCloseableBottomSheet 
         resources.updateConfiguration(newConfig, resources.displayMetrics)
 
         bottomSheetBehavior.peekHeight = resources.getDimensionPixelSize(R.dimen.quest_form_peekHeight)
+        bottomSheetBehavior.maxHeight = maxBottomSheetHeightPx()
         bottomSheetContainer.updateLayoutParams { width = resources.getDimensionPixelSize(R.dimen.quest_form_width) }
     }
+
+    // When dragged/expanded, the sheet's height otherwise grows with its content (wrap_content) up
+    // to the full screen - cap it at 90% so it never covers the whole screen, leaving a sliver of
+    // the map visible above it as a drag affordance.
+    private fun maxBottomSheetHeightPx(): Int =
+        (resources.displayMetrics.heightPixels * 0.85f).toInt()
 
     fun expand() {
         bottomSheetBehavior.state = STATE_EXPANDED

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/controls/QuestSelectionBottomSheet.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/controls/QuestSelectionBottomSheet.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.intl.Locale
@@ -49,7 +50,14 @@ fun QuestSelectionBottomSheet(
         viewModel.currentCountry?.let { getCountryName(it) } ?: "Atlantis"
     }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val maxSheetHeight = LocalWindowInfo.current.containerSize.height.dp * 0.85f
+    // containerSize is in pixels - .dp on a raw Int does NOT do a px-to-dp conversion (it just
+    // wraps the number as-is), so this must go through the actual screen density or the resulting
+    // "80%" is several times larger than the real screen height and never actually constrains
+    // anything, letting the sheet expand to fill the whole screen regardless of the fraction used.
+    val density = LocalDensity.current
+    val maxSheetHeight = with(density) {
+        LocalWindowInfo.current.containerSize.height.toDp()
+    } * 0.8f
     // Swallow any scroll/fling leftover from the lists below so it never bubbles up into the
     // sheet's own drag-to-dismiss handling - only the sheet's drag handle should move the sheet
     val blockSheetDragFromContent = remember {

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/controls/QuestSelectionBottomSheet.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/controls/QuestSelectionBottomSheet.kt
@@ -2,7 +2,6 @@ package de.westnordost.streetcomplete.screens.main.controls
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -21,11 +20,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import de.westnordost.streetcomplete.screens.settings.quest_selection.HiddenQuestsSection
 import de.westnordost.streetcomplete.screens.settings.quest_selection.QuestSelectionList
 import de.westnordost.streetcomplete.screens.settings.quest_selection.QuestSelectionViewModel
 import de.westnordost.streetcomplete.util.ktx.displayRegion
@@ -39,11 +44,26 @@ fun QuestSelectionBottomSheet(
     onClose: () -> Unit,
 ) {
     val filteredQuests by viewModel.filteredQuests.collectAsStateWithLifecycle()
+    val hiddenQuests by viewModel.hiddenQuests.collectAsStateWithLifecycle()
     val displayCountry = remember {
         viewModel.currentCountry?.let { getCountryName(it) } ?: "Atlantis"
     }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val maxSheetHeight =  LocalWindowInfo.current.containerSize.height.dp * 0.85f
+    val maxSheetHeight = LocalWindowInfo.current.containerSize.height.dp * 0.85f
+    // Swallow any scroll/fling leftover from the lists below so it never bubbles up into the
+    // sheet's own drag-to-dismiss handling - only the sheet's drag handle should move the sheet
+    val blockSheetDragFromContent = remember {
+        object : NestedScrollConnection {
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource,
+            ): Offset = available
+
+            override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity =
+                available
+        }
+    }
     ModalBottomSheet(
         onDismissRequest = onClose,
         sheetState = sheetState,
@@ -54,6 +74,7 @@ fun QuestSelectionBottomSheet(
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(max = maxSheetHeight)
+                .nestedScroll(blockSheetDragFromContent)
         ) {
             Box(
                 modifier = Modifier
@@ -90,6 +111,14 @@ fun QuestSelectionBottomSheet(
                 displayCountry = displayCountry,
                 onSelect = { questType, selected -> viewModel.select(questType, selected) },
                 onReorder = { questType, toAfter -> viewModel.order(questType, toAfter) },
+                modifier = Modifier.weight(1f),
+            )
+
+            HiddenQuestsSection(
+                items = hiddenQuests,
+                onUnhide = { key -> viewModel.unhideQuest(key) },
+                onUnhideAll = { viewModel.unhideAllQuests() },
+                modifier = Modifier.weight(1f),
             )
         }
     }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/controls/QuestSelectionBottomSheet.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/controls/QuestSelectionBottomSheet.kt
@@ -2,7 +2,9 @@ package de.westnordost.streetcomplete.screens.main.controls
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -91,13 +93,14 @@ fun QuestSelectionBottomSheet(
             ) {
                 Column(modifier = Modifier.padding(end = 40.dp)) {
                     Text(
-                        text = "Choose which features to survey",
+                        text = "Manage Quests",
                         style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
                         color = MaterialTheme.colorScheme.primary,
                     )
+                    Spacer(modifier = Modifier.height(32.dp))
                     Text(
-                        text = "Show all hidden elements on the map by individual item or type",
-                        style = MaterialTheme.typography.bodyMedium,
+                        text = "Show or hide elements on the map by individual item or type",
+                        style = MaterialTheme.typography.titleSmall,
                         color = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.padding(top = 4.dp)
                     )

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/SettingsModule.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/SettingsModule.kt
@@ -13,8 +13,8 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val settingsModule = module {
-    viewModel<SettingsViewModel> { SettingsViewModelImpl(get(), get(), get(), get(), get(), get(), get(), get()) }
-    viewModel<QuestSelectionViewModel> { QuestSelectionViewModelImpl(get(), get(), get(), get(), get(), get(named("CountryBoundariesLazy")), get()) }
+    viewModel<SettingsViewModel> { SettingsViewModelImpl(get(), get(), get(), get(), get(), get(), get()) }
+    viewModel<QuestSelectionViewModel> { QuestSelectionViewModelImpl(get(), get(), get(), get(), get(), get(), get(named("CountryBoundariesLazy")), get()) }
     viewModel<OverlaySelectionViewModel> { OverlaySelectionViewModelImpl(get(), get(), get()) }
     viewModel<EditTypePresetsViewModel> { EditTypePresetsViewModelImpl(get(), get(), get(), get()) }
     viewModel<ShowQuestFormsViewModel> { ShowQuestFormsViewModelImpl(get(), get()) }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/SettingsNavHost.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/SettingsNavHost.kt
@@ -39,9 +39,7 @@ import org.koin.androidx.compose.koinViewModel
             SettingsScreen(
                 viewModel = koinViewModel(),
                 onClickShowQuestForms = { navController.navigate(SettingsDestination.ShowQuestForms) },
-                onClickPresetSelection = { navController.navigate(SettingsDestination.EditTypePresets) },
                 onClickQuestSelection = { navController.navigate(SettingsDestination.QuestSelection) },
-                onClickOverlaySelection = { navController.navigate(SettingsDestination.OverlaySelection) },
                 onClickBack = ::goBack
             )
         }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/SettingsScreen.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/SettingsScreen.kt
@@ -53,15 +53,11 @@ import de.westnordost.streetcomplete.resources.pref_title_delete_cache_summary
 import de.westnordost.streetcomplete.resources.pref_title_keep_screen_on
 import de.westnordost.streetcomplete.resources.pref_title_language_select2
 import de.westnordost.streetcomplete.resources.pref_title_quests2
-import de.westnordost.streetcomplete.resources.pref_title_quests_restore_hidden
-import de.westnordost.streetcomplete.resources.pref_title_quests_restore_hidden_summary
 import de.westnordost.streetcomplete.resources.pref_title_resurvey_intervals
 import de.westnordost.streetcomplete.resources.pref_title_sync2
 import de.westnordost.streetcomplete.resources.pref_title_theme_select
 import de.westnordost.streetcomplete.resources.pref_title_zoom_buttons
 import de.westnordost.streetcomplete.resources.quest_presets_default_name
-import de.westnordost.streetcomplete.resources.restore_confirmation
-import de.westnordost.streetcomplete.resources.restore_dialog_message
 import de.westnordost.streetcomplete.resources.resurvey_intervals_default
 import de.westnordost.streetcomplete.resources.resurvey_intervals_less_often
 import de.westnordost.streetcomplete.resources.resurvey_intervals_more_often
@@ -87,12 +83,9 @@ import org.jetbrains.compose.resources.stringResource
 fun SettingsScreen(
     viewModel: SettingsViewModel,
     onClickShowQuestForms: () -> Unit,
-    onClickPresetSelection: () -> Unit,
     onClickQuestSelection: () -> Unit,
-    onClickOverlaySelection: () -> Unit,
     onClickBack: () -> Unit,
 ) {
-    val hiddenQuestCount by viewModel.hiddenQuestCount.collectAsState()
     val questTypeCount by viewModel.questTypeCount.collectAsState()
     val overlayCount by viewModel.overlayCount.collectAsState()
     val selectedPresetName by viewModel.selectedEditTypePresetName.collectAsState()
@@ -107,7 +100,6 @@ fun SettingsScreen(
     val selectedLanguage by viewModel.selectedLanguage.collectAsState()
 
     var showDeleteCacheConfirmation by remember { mutableStateOf(false) }
-    var showRestoreHiddenQuestsConfirmation by remember { mutableStateOf(false) }
     var showUploadTutorialInfo by remember { mutableStateOf(false) }
 
     var showThemeSelect by remember { mutableStateOf(false) }
@@ -133,55 +125,55 @@ fun SettingsScreen(
                     )
                 )
         ) {
-            PreferenceCategory(stringResource(Res.string.pref_category_quests)) {
-
-                // Preference(
-                //     name = stringResource(Res.string.action_manage_presets),
-                //     onClick = onClickPresetSelection,
-                //     description = stringResource(Res.string.action_manage_presets_summary)
-                // ) {
-                //     Text(presetNameOrDefault)
-                //     NextScreenIcon()
-                // }
-
-                Preference(
-                    name = stringResource(Res.string.pref_title_quests2),
-                    onClick = onClickQuestSelection,
-                    description = questTypeCount?.let {
-                        stringResource(Res.string.pref_subtitle_quests, it.enabled, it.total)
-                    }
-                ) { NextScreenIcon() }
-
-                // Preference(
-                //     name = stringResource(Res.string.pref_title_overlays),
-                //     onClick = onClickOverlaySelection,
-                //     description = overlayCount?.let {
-                //         stringResource(Res.string.pref_subtitle_quests, it.enabled, it.total)
-                //     }
-                // ) { NextScreenIcon() }
-
-                // Preference(
-                //     name = stringResource(Res.string.pref_title_resurvey_intervals),
-                //     onClick = { showResurveyIntervalsSelect = true },
-                //     description = stringResource(Res.string.pref_title_resurvey_intervals_summary)
-                // ) {
-                //     Text(stringResource(resurveyIntervals.title))
-                // }
-                //
-                // Preference(
-                //     name = stringResource(Res.string.pref_title_show_notes_not_phrased_as_questions),
-                //     onClick = { viewModel.setShowAllNotes(!showAllNotes) },
-                //     description = stringResource(
-                //         if (showAllNotes) Res.string.pref_summaryOn_show_notes_not_phrased_as_questions
-                //         else Res.string.pref_summaryOff_show_notes_not_phrased_as_questions
-                //     )
-                // ) {
-                //     Switch(
-                //         checked = showAllNotes,
-                //         onCheckedChange = { viewModel.setShowAllNotes(it) }
-                //     )
-                // }
-            }
+            // PreferenceCategory(stringResource(Res.string.pref_category_quests)) {
+            //
+            //     // Preference(
+            //     //     name = stringResource(Res.string.action_manage_presets),
+            //     //     onClick = onClickPresetSelection,
+            //     //     description = stringResource(Res.string.action_manage_presets_summary)
+            //     // ) {
+            //     //     Text(presetNameOrDefault)
+            //     //     NextScreenIcon()
+            //     // }
+            //
+            //     // Preference(
+            //     //     name = stringResource(Res.string.pref_title_quests2),
+            //     //     onClick = onClickQuestSelection,
+            //     //     description = questTypeCount?.let {
+            //     //         stringResource(Res.string.pref_subtitle_quests, it.enabled, it.total)
+            //     //     }
+            //     // ) { NextScreenIcon() }
+            //
+            //     // Preference(
+            //     //     name = stringResource(Res.string.pref_title_overlays),
+            //     //     onClick = onClickOverlaySelection,
+            //     //     description = overlayCount?.let {
+            //     //         stringResource(Res.string.pref_subtitle_quests, it.enabled, it.total)
+            //     //     }
+            //     // ) { NextScreenIcon() }
+            //
+            //     // Preference(
+            //     //     name = stringResource(Res.string.pref_title_resurvey_intervals),
+            //     //     onClick = { showResurveyIntervalsSelect = true },
+            //     //     description = stringResource(Res.string.pref_title_resurvey_intervals_summary)
+            //     // ) {
+            //     //     Text(stringResource(resurveyIntervals.title))
+            //     // }
+            //     //
+            //     // Preference(
+            //     //     name = stringResource(Res.string.pref_title_show_notes_not_phrased_as_questions),
+            //     //     onClick = { viewModel.setShowAllNotes(!showAllNotes) },
+            //     //     description = stringResource(
+            //     //         if (showAllNotes) Res.string.pref_summaryOn_show_notes_not_phrased_as_questions
+            //     //         else Res.string.pref_summaryOff_show_notes_not_phrased_as_questions
+            //     //     )
+            //     // ) {
+            //     //     Switch(
+            //     //         checked = showAllNotes,
+            //     //         onCheckedChange = { viewModel.setShowAllNotes(it) }
+            //     //     )
+            //     // }
+            // }
 
             PreferenceCategory(stringResource(Res.string.pref_category_communication)) {
                 Preference(
@@ -239,15 +231,6 @@ fun SettingsScreen(
                     onClick = { showDeleteCacheConfirmation = true },
                     description = stringResource(Res.string.pref_title_delete_cache_summary)
                 )
-
-                Preference(
-                    name = stringResource(Res.string.pref_title_quests_restore_hidden),
-                    onClick = { showRestoreHiddenQuestsConfirmation = true },
-                    description = stringResource(
-                        Res.string.pref_title_quests_restore_hidden_summary,
-                        hiddenQuestCount
-                    )
-                )
             }
 
             if (BuildConfig.DEBUG) {
@@ -276,14 +259,6 @@ fun SettingsScreen(
                 )
             },
             confirmButtonText = stringResource(Res.string.delete_confirmation)
-        )
-    }
-    if (showRestoreHiddenQuestsConfirmation) {
-        ConfirmationDialog(
-            onDismissRequest = { showRestoreHiddenQuestsConfirmation = false },
-            onConfirmed = { viewModel.unhideQuests() },
-            title = { Text(stringResource(Res.string.restore_dialog_message)) },
-            confirmButtonText = stringResource(Res.string.restore_confirmation)
         )
     }
     if (showUploadTutorialInfo) {
@@ -364,7 +339,7 @@ private val ResurveyIntervals.title: StringResource
         ResurveyIntervals.MORE_OFTEN -> Res.string.resurvey_intervals_more_often
     }
 
-private val Theme.title: StringResource
+val Theme.title: StringResource
     get() = when (this) {
         Theme.LIGHT -> Res.string.theme_light
         Theme.DARK -> Res.string.theme_dark

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/SettingsViewModel.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/SettingsViewModel.kt
@@ -13,11 +13,8 @@ import de.westnordost.streetcomplete.data.preferences.ResurveyIntervals
 import de.westnordost.streetcomplete.data.preferences.Theme
 import de.westnordost.streetcomplete.data.presets.EditTypePreset
 import de.westnordost.streetcomplete.data.presets.EditTypePresetsSource
-import de.westnordost.streetcomplete.data.quest.QuestKey
 import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
-import de.westnordost.streetcomplete.data.visiblequests.QuestsHiddenController
-import de.westnordost.streetcomplete.data.visiblequests.QuestsHiddenSource
 import de.westnordost.streetcomplete.data.visiblequests.VisibleEditTypeSource
 import de.westnordost.streetcomplete.resources.Res
 import de.westnordost.streetcomplete.ui.ktx.readYaml
@@ -30,7 +27,6 @@ import kotlinx.coroutines.flow.StateFlow
 abstract class SettingsViewModel : ViewModel() {
     abstract val selectableLanguageCodes: StateFlow<List<String>?>
     abstract val selectedEditTypePresetName: StateFlow<String?>
-    abstract val hiddenQuestCount: StateFlow<Int>
     abstract val questTypeCount: StateFlow<QuestTypeCount?>
     abstract val overlayCount: StateFlow<QuestTypeCount?>
 
@@ -41,8 +37,6 @@ abstract class SettingsViewModel : ViewModel() {
     abstract val keepScreenOn: StateFlow<Boolean>
     abstract val showZoomButtons: StateFlow<Boolean>
     abstract val selectedLanguage: StateFlow<String?>
-
-    abstract fun unhideQuests()
 
     abstract fun deleteCache()
 
@@ -62,7 +56,6 @@ class SettingsViewModelImpl(
     private val prefs: Preferences,
     private val res: Res,
     private val cleaner: Cleaner,
-    private val hiddenQuestsController: QuestsHiddenController,
     private val questTypeRegistry: QuestTypeRegistry,
     private val overlayRegistry: OverlayRegistry,
     private val visibleEditTypeSource: VisibleEditTypeSource,
@@ -87,13 +80,6 @@ class SettingsViewModelImpl(
         override fun onDeleted(presetId: Long) { updateSelectedEditTypePreset() }
     }
 
-    private val hiddenQuestsListener = object : QuestsHiddenSource.Listener {
-        override fun onHid(key: QuestKey, timestamp: Long) { updateHiddenQuests() }
-        override fun onUnhid(key: QuestKey, timestamp: Long) { updateHiddenQuests() }
-        override fun onUnhidAll() { updateHiddenQuests() }
-    }
-
-    override val hiddenQuestCount = MutableStateFlow(0)
     override val questTypeCount = MutableStateFlow<QuestTypeCount?>(null)
     override val overlayCount = MutableStateFlow<QuestTypeCount?>(null)
     override val selectedEditTypePresetName = MutableStateFlow<String?>(null)
@@ -112,7 +98,6 @@ class SettingsViewModelImpl(
     init {
         visibleEditTypeSource.addListener(visibleEditTypeListener)
         editTypePresetsSource.addListener(editTypePresetsListener)
-        hiddenQuestsController.addListener(hiddenQuestsListener)
 
         listeners += prefs.onResurveyIntervalsChanged { resurveyIntervals.value = it }
         listeners += prefs.onAutosyncChanged { autosync.value = it }
@@ -125,14 +110,12 @@ class SettingsViewModelImpl(
         updateQuestTypeCount()
         updateOverlayCount()
         updateSelectableLanguageCodes()
-        updateHiddenQuests()
         updateSelectedEditTypePreset()
     }
 
     override fun onCleared() {
         visibleEditTypeSource.removeListener(visibleEditTypeListener)
         editTypePresetsSource.removeListener(editTypePresetsListener)
-        hiddenQuestsController.removeListener(hiddenQuestsListener)
 
         listeners.forEach { it.deactivate() }
         listeners.clear()
@@ -150,12 +133,6 @@ class SettingsViewModelImpl(
     override fun setShowZoomButtons(value: Boolean) { prefs.showZoomButtons = value }
     override fun setSelectedLanguage(value: String?) { prefs.language = value }
 
-    override fun unhideQuests() {
-        launch(IO) {
-            hiddenQuestsController.unhideAll()
-        }
-    }
-
     private fun updateSelectedEditTypePreset() {
         launch(IO) {
             selectedEditTypePresetName.value = editTypePresetsSource.selectedEditTypePresetName
@@ -165,12 +142,6 @@ class SettingsViewModelImpl(
     private fun updateSelectableLanguageCodes() {
         launch {
             selectableLanguageCodes.value = res.readYaml<List<String>>("files/languages.yml")
-        }
-    }
-
-    private fun updateHiddenQuests() {
-        launch(IO) {
-            hiddenQuestCount.value = hiddenQuestsController.countAll()
         }
     }
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/HiddenQuest.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/HiddenQuest.kt
@@ -1,0 +1,13 @@
+package de.westnordost.streetcomplete.screens.settings.quest_selection
+
+import androidx.compose.runtime.Immutable
+import de.westnordost.streetcomplete.data.quest.QuestKey
+import de.westnordost.streetcomplete.data.quest.QuestType
+
+/** A single previously-hidden quest instance, to be shown in the restore list */
+@Immutable
+data class HiddenQuest(
+    val key: QuestKey,
+    val questType: QuestType?,
+    val timestamp: Long,
+)

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/HiddenQuestsSection.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/HiddenQuestsSection.kt
@@ -62,11 +62,12 @@ fun HiddenQuestsSection(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "HIDDEN ELEMENTS",
+                text = "Hidden Elements",
                 style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .padding(top = 4.dp)
+                    .weight(1f),
             )
             Button(
                 onClick = { showUnhideAllConfirmation = true },
@@ -77,7 +78,7 @@ fun HiddenQuestsSection(
         }
         Text(
             text = "Swipe left on an item to unhide it and remove it from this list.",
-            style = MaterialTheme.typography.bodySmall,
+            style = MaterialTheme.typography.bodyMedium,
             color = LocalContentColor.current.copy(alpha = 0.6f),
             modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
         )

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/HiddenQuestsSection.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/HiddenQuestsSection.kt
@@ -1,0 +1,189 @@
+package de.westnordost.streetcomplete.screens.settings.quest_selection
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Undo
+import androidx.compose.material3.Button
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import de.westnordost.streetcomplete.data.quest.OsmNoteQuestKey
+import de.westnordost.streetcomplete.data.quest.OsmQuestKey
+import de.westnordost.streetcomplete.data.quest.QuestKey
+import de.westnordost.streetcomplete.quests.sidewalk_long_form.AddGenericLong
+import de.westnordost.streetcomplete.resources.Res
+import de.westnordost.streetcomplete.resources.restore_confirmation
+import de.westnordost.streetcomplete.resources.restore_dialog_message
+import de.westnordost.streetcomplete.ui.common.dialogs.ConfirmationDialog
+import org.jetbrains.compose.resources.stringResource
+
+/** Shows the list of individually hidden quest instances, with the option to unhide each one
+ *  (by swiping it away) or all of them at once. Rendered below the quest type selection list */
+@Composable
+fun HiddenQuestsSection(
+    items: List<HiddenQuest>,
+    onUnhide: (QuestKey) -> Unit,
+    onUnhideAll: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showUnhideAllConfirmation by remember { mutableStateOf(false) }
+
+    Column(modifier) {
+        Divider()
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "HIDDEN ELEMENTS",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.weight(1f),
+            )
+            Button(
+                onClick = { showUnhideAllConfirmation = true },
+                enabled = items.isNotEmpty(),
+            ) {
+                Text("Unhide All")
+            }
+        }
+        Text(
+            text = "Swipe left on an item to unhide it and remove it from this list.",
+            style = MaterialTheme.typography.bodySmall,
+            color = LocalContentColor.current.copy(alpha = 0.6f),
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+        )
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            contentPadding = PaddingValues(bottom = 8.dp),
+        ) {
+            if (items.isEmpty()) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 24.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = "No hidden elements",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = LocalContentColor.current.copy(alpha = 0.6f),
+                        )
+                    }
+                }
+            }
+            items(items, key = { it.key.listKey() }) { item ->
+                HiddenQuestRow(
+                    item = item,
+                    onUnhide = { onUnhide(item.key) },
+                )
+            }
+        }
+    }
+
+    if (showUnhideAllConfirmation) {
+        ConfirmationDialog(
+            onDismissRequest = { showUnhideAllConfirmation = false },
+            onConfirmed = onUnhideAll,
+            title = { Text(stringResource(Res.string.restore_dialog_message)) },
+            confirmButtonText = stringResource(Res.string.restore_confirmation)
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HiddenQuestRow(item: HiddenQuest, onUnhide: () -> Unit) {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) onUnhide()
+            true
+        }
+    )
+    SwipeToDismissBox(
+        state = dismissState,
+        enableDismissFromStartToEnd = false,
+        backgroundContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .padding(horizontal = 20.dp),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Undo,
+                    contentDescription = "Unhide",
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+        },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surface)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = item.idLabel,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = item.title,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+            Divider()
+        }
+    }
+}
+
+private val HiddenQuest.title: String
+    get() = (questType as? AddGenericLong)?.item?.elementType ?: "Create Note"
+
+private val HiddenQuest.idLabel: String
+    get() = when (val key = key) {
+        is OsmQuestKey -> "ID: ${key.elementId}"
+        is OsmNoteQuestKey -> "ID: ${key.noteId}"
+    }
+
+private fun QuestKey.listKey(): String = when (this) {
+    is OsmQuestKey -> "osm_${elementType}_${elementId}_${questTypeName}_$workspaceId"
+    is OsmNoteQuestKey -> "note_$noteId"
+}

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionList.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionList.kt
@@ -93,6 +93,7 @@ fun QuestSelectionList(
         //      single place that could have a scrollbar
         LazyColumn(
             state = listState,
+            modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(
                 start = contentPadding.calculateStartPadding(layoutDirection),
                 end = contentPadding.calculateEndPadding(layoutDirection),

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionViewModel.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/QuestSelectionViewModel.kt
@@ -12,12 +12,18 @@ import de.westnordost.streetcomplete.data.presets.EditTypePresetsSource
 import de.westnordost.streetcomplete.data.quest.AllCountries
 import de.westnordost.streetcomplete.data.quest.AllCountriesExcept
 import de.westnordost.streetcomplete.data.quest.NoCountriesExcept
+import de.westnordost.streetcomplete.data.quest.OsmNoteQuestKey
+import de.westnordost.streetcomplete.data.quest.OsmQuestKey
+import de.westnordost.streetcomplete.data.quest.QuestKey
 import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.data.visiblequests.QuestTypeOrderController
 import de.westnordost.streetcomplete.data.visiblequests.QuestTypeOrderSource
+import de.westnordost.streetcomplete.data.visiblequests.QuestsHiddenController
+import de.westnordost.streetcomplete.data.visiblequests.QuestsHiddenSource
 import de.westnordost.streetcomplete.data.visiblequests.VisibleEditTypeController
 import de.westnordost.streetcomplete.data.visiblequests.VisibleEditTypeSource
+import de.westnordost.streetcomplete.quests.note_discussion.OsmNoteQuestType
 import de.westnordost.streetcomplete.util.ResourceProvider
 import de.westnordost.streetcomplete.util.ktx.containsAll
 import de.westnordost.streetcomplete.util.ktx.containsAny
@@ -38,12 +44,15 @@ abstract class QuestSelectionViewModel : ViewModel() {
     abstract val filteredQuests: StateFlow<List<QuestSelection>>
     abstract val currentCountry: String?
     abstract val selectedEditTypePresetName: StateFlow<String?>
+    abstract val hiddenQuests: StateFlow<List<HiddenQuest>>
 
     abstract fun select(questType: QuestType, selected: Boolean)
     abstract fun order(questType: QuestType, toAfter: QuestType)
     abstract fun unselectAll()
     abstract fun resetAll()
     abstract fun updateSearchText(text: String)
+    abstract fun unhideQuest(key: QuestKey)
+    abstract fun unhideAllQuests()
 }
 
 @Stable
@@ -53,6 +62,7 @@ class QuestSelectionViewModelImpl(
     private val editTypePresetsSource: EditTypePresetsSource,
     private val visibleEditTypeController: VisibleEditTypeController,
     private val questTypeOrderController: QuestTypeOrderController,
+    private val hiddenQuestsController: QuestsHiddenController,
     countryBoundaries: Lazy<CountryBoundaries>,
     prefs: Preferences,
 ) : QuestSelectionViewModel() {
@@ -74,7 +84,9 @@ class QuestSelectionViewModelImpl(
         }
 
         // all/many visibilities have changed - re-init list
-        override fun onVisibilitiesChanged() { initQuests() }
+        override fun onVisibilitiesChanged() {
+            initQuests()
+        }
     }
 
     private val questTypeOrderListener = object : QuestTypeOrderSource.Listener {
@@ -91,17 +103,38 @@ class QuestSelectionViewModelImpl(
         }
 
         // all/many quest orders have been changed - re-init list
-        override fun onQuestTypeOrdersChanged() { initQuests() }
+        override fun onQuestTypeOrdersChanged() {
+            initQuests()
+        }
     }
 
     private val editTypePresetsListener = object : EditTypePresetsSource.Listener {
-        override fun onSelectionChanged() { updateSelectedEditTypePresetName() }
+        override fun onSelectionChanged() {
+            updateSelectedEditTypePresetName()
+        }
+
         override fun onAdded(preset: EditTypePreset) {}
         override fun onRenamed(preset: EditTypePreset) {}
         override fun onDeleted(presetId: Long) {}
     }
 
+    private val hiddenQuestsListener = object : QuestsHiddenSource.Listener {
+        override fun onHid(key: QuestKey, timestamp: Long) {
+            updateHiddenQuests()
+        }
+
+        override fun onUnhid(key: QuestKey, timestamp: Long) {
+            updateHiddenQuests()
+        }
+
+        override fun onUnhidAll() {
+            updateHiddenQuests()
+        }
+    }
+
     private val quests = MutableStateFlow<List<QuestSelection>>(emptyList())
+
+    override val hiddenQuests = MutableStateFlow<List<HiddenQuest>>(emptyList())
 
     override val filteredQuests: StateFlow<List<QuestSelection>> =
         combine(quests, searchText, questTitles) { quests, searchText, titles ->
@@ -119,9 +152,11 @@ class QuestSelectionViewModelImpl(
         initQuests()
         updateSelectedEditTypePresetName()
         loadQuestTitles()
+        updateHiddenQuests()
         editTypePresetsSource.addListener(editTypePresetsListener)
         visibleEditTypeController.addListener(visibleEditTypeListener)
         questTypeOrderController.addListener(questTypeOrderListener)
+        hiddenQuestsController.addListener(hiddenQuestsListener)
     }
 
     private fun updateSelectedEditTypePresetName() {
@@ -144,6 +179,7 @@ class QuestSelectionViewModelImpl(
         editTypePresetsSource.removeListener(editTypePresetsListener)
         visibleEditTypeController.removeListener(visibleEditTypeListener)
         questTypeOrderController.removeListener(questTypeOrderListener)
+        hiddenQuestsController.removeListener(hiddenQuestsListener)
     }
 
     override fun select(questType: QuestType, selected: Boolean) {
@@ -175,16 +211,44 @@ class QuestSelectionViewModelImpl(
         searchText.value = text
     }
 
+    override fun unhideQuest(key: QuestKey) {
+        launch(IO) {
+            hiddenQuestsController.unhide(key)
+        }
+    }
+
+    override fun unhideAllQuests() {
+        launch(IO) {
+            hiddenQuestsController.unhideAll()
+        }
+    }
+
+    private fun updateHiddenQuests() {
+        launch(IO) {
+            hiddenQuests.value =
+                hiddenQuestsController.getAllNewerThan(0L).map { (key, timestamp) ->
+                    HiddenQuest(key = key, questType = resolveQuestType(key), timestamp = timestamp)
+                }
+        }
+    }
+
+    private fun resolveQuestType(key: QuestKey): QuestType? = when (key) {
+        is OsmQuestKey -> questTypeRegistry.getByName(key.questTypeName)
+        is OsmNoteQuestKey -> OsmNoteQuestType
+    }
+
     private fun initQuests() {
         launch(IO) {
             val sortedQuestTypes = questTypeRegistry.toMutableList()
             questTypeOrderController.sort(sortedQuestTypes)
             quests.value = sortedQuestTypes
-                .map { QuestSelection(
-                    questType = it,
-                    selected = visibleEditTypeController.isVisible(it),
-                    enabledInCurrentCountry = isQuestEnabledInCurrentCountry(it)
-                ) }
+                .map {
+                    QuestSelection(
+                        questType = it,
+                        selected = visibleEditTypeController.isVisible(it),
+                        enabledInCurrentCountry = isQuestEnabledInCurrentCountry(it)
+                    )
+                }
                 .toMutableList()
         }
     }
@@ -203,12 +267,15 @@ class QuestSelectionViewModelImpl(
         filter: String,
         titles: Map<String, String>,
     ): List<QuestSelection> {
-        val words = filter.takeIf { it.isNotBlank() }?.trim()?.lowercase()?.split(' ') ?: emptyList()
+        val words =
+            filter.takeIf { it.isNotBlank() }?.trim()?.lowercase()?.split(' ') ?: emptyList()
         return if (words.isEmpty()) {
             quests
         } else {
             quests.filter { quest ->
-                titles[quest.questType.name]?.lowercase()?.containsAll(words) == true || quest.questType.name.lowercase().containsAll(words)
+                titles[quest.questType.name]?.lowercase()
+                    ?.containsAll(words) == true || quest.questType.name.lowercase()
+                    .containsAll(words)
             }
         }
     }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/user/ProfileScreenNew.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/user/ProfileScreenNew.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -50,11 +49,18 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.data.preferences.Preferences
+import de.westnordost.streetcomplete.data.preferences.Theme
+import de.westnordost.streetcomplete.resources.Res
+import de.westnordost.streetcomplete.resources.pref_title_theme_select
 import de.westnordost.streetcomplete.screens.settings.SettingsViewModel
+import de.westnordost.streetcomplete.screens.settings.title
 import de.westnordost.streetcomplete.screens.workspaces.WorkSpaceActivity
 import de.westnordost.streetcomplete.ui.common.BackIcon
 import de.westnordost.streetcomplete.ui.common.UserInitialsAvatar
+import de.westnordost.streetcomplete.ui.common.dialogs.SimpleListPickerDialog
+import de.westnordost.streetcomplete.ui.common.settings.Preference
 import de.westnordost.streetcomplete.util.creds_manager.SecureCredentialStorage
+import org.jetbrains.compose.resources.stringResource
 import kotlin.reflect.KSuspendFunction1
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -70,6 +76,8 @@ fun ProfileScreenNewContent(
     var lowBandwidthModeEnabled by remember { mutableStateOf(preferences.isLowBandwidthModeEnabled) }
     var isFollowModeEnabled by remember { mutableStateOf(preferences.isFollowModeEnabled) }
     val userName by viewModel.userName.collectAsState()
+    var showThemeSelect by remember { mutableStateOf(false) }
+    val theme by settingsViewModel.theme.collectAsState()
 
     Column(
         modifier = Modifier
@@ -104,7 +112,7 @@ fun ProfileScreenNewContent(
                 color = MaterialTheme.colorScheme.onSurface,
                 style = MaterialTheme.typography.titleMedium,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.semantics{
+                modifier = Modifier.semantics {
                     val info = userName?.split("\n") ?: emptyList()
                     val email = info.getOrNull(0) ?: "Unknown"
                     val name = info.getOrNull(1) ?: "Unknown"
@@ -171,6 +179,17 @@ fun ProfileScreenNewContent(
                 }
             }
 
+            if (showThemeSelect) {
+                SimpleListPickerDialog(
+                    onDismissRequest = { showThemeSelect = false },
+                    items = Theme.entries,
+                    onItemSelected = { settingsViewModel.setTheme(it) },
+                    title = { Text(stringResource(Res.string.pref_title_theme_select)) },
+                    selectedItem = theme,
+                    getItemName = { stringResource(it.title) }
+                )
+            }
+
             PreferenceRow(
                 stringResource(R.string.diable_biometric_title),
                 stringResource(R.string.disable_biometric_message),
@@ -186,6 +205,13 @@ fun ProfileScreenNewContent(
                 onCheckedChange = { newValue ->
                     lowBandwidth = newValue // trigger LaunchedEffect
                 })
+
+            Preference(
+                name = stringResource(Res.string.pref_title_theme_select),
+                onClick = { showThemeSelect = true },
+            ) {
+                Text(stringResource(theme.title))
+            }
 
             // PreferenceRow(
             //     stringResource(R.string.follow_mode),

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/user/UserActivity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/user/UserActivity.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.compose.material3.Surface
+import androidx.core.app.ActivityCompat
+import com.russhwolf.settings.SettingsListener
 import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.screens.BaseActivity
 import de.westnordost.streetcomplete.screens.settings.SettingsViewModel
@@ -20,6 +22,8 @@ class UserActivity : BaseActivity() {
     private val settingsViewModel by viewModel<SettingsViewModel>()
     private val preferences: Preferences by inject()
 
+    private val listeners = mutableListOf<SettingsListener>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -35,6 +39,20 @@ class UserActivity : BaseActivity() {
                 }
             }
         }
+
+        // AppTheme only follows isSystemInDarkTheme(), which reflects AppCompatDelegate's night
+        // mode - that's only updated (via StreetCompleteApplication's own theme listener) after
+        // this preference changes, and Compose has no way to know a Configuration change is coming
+        // from that until it's actually delivered. Recreating (same fix SettingsActivity already
+        // uses for its own theme picker) forces AppTheme to recompose against the now-current night
+        // mode immediately, instead of only looking right after leaving and reopening this screen.
+        listeners += preferences.onThemeChanged { ActivityCompat.recreate(this) }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        listeners.forEach { it.deactivate() }
+        listeners.clear()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/androidMain/res/drawable/bg_drag_handle.xml
+++ b/app/src/androidMain/res/drawable/bg_drag_handle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/divider" />
+    <corners android:radius="2dp" />
+</shape>

--- a/app/src/androidMain/res/drawable/ic_outline_tune_24.xml
+++ b/app/src/androidMain/res/drawable/ic_outline_tune_24.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportHeight="960"
+    android:viewportWidth="960"
+    android:width="24dp">
+
+    <path
+        android:fillColor="?attr/colorControlNormal"
+        android:pathData="M440,840L440,600L520,600L520,680L840,680L840,760L520,760L520,840L440,840ZM120,760L120,680L360,680L360,760L120,760ZM280,600L280,520L120,520L120,440L280,440L280,360L360,360L360,600L280,600ZM440,520L440,440L840,440L840,520L440,520ZM600,360L600,120L680,120L680,200L840,200L840,280L680,280L680,360L600,360ZM120,280L120,200L520,200L520,280L120,280Z" />
+
+</vector>

--- a/app/src/androidMain/res/layout/activity_main.xml
+++ b/app/src/androidMain/res/layout/activity_main.xml
@@ -24,6 +24,7 @@
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/controls"
+        android:layout_below="@id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 

--- a/app/src/androidMain/res/layout/custom_toolbar.xml
+++ b/app/src/androidMain/res/layout/custom_toolbar.xml
@@ -73,7 +73,7 @@
             android:scaleType="centerInside"
             android:visibility="visible"
             app:srcCompat="@drawable/outline_accessibility_24"
-            app:tint="#2D0369" />
+            app:tint="@color/primary" />
 
         <de.westnordost.streetcomplete.screens.main.UploadButton
             android:id="@+id/uploadButton"
@@ -90,12 +90,12 @@
             android:layout_width="@dimen/map_button_size"
             android:layout_height="@dimen/map_button_size"
             android:contentDescription="@string/map_btn_menu"
-            android:scaleType="fitCenter"
+            android:scaleType="centerInside"
             android:elevation="4dp"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_menu_24dp"
-            app:tint="#2D0369" />
+            app:srcCompat="@drawable/ic_outline_tune_24"
+            app:tint="@color/primary" />
 
     </LinearLayout>
 

--- a/app/src/androidMain/res/layout/fragment_quest_answer.xml
+++ b/app/src/androidMain/res/layout/fragment_quest_answer.xml
@@ -31,6 +31,15 @@
             android:clipChildren="true"
             app:behavior_peekHeight="@dimen/quest_form_peekHeight">
 
+            <View
+                android:id="@+id/dragHandle"
+                android:layout_width="32dp"
+                android:layout_height="4dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="8dp"
+                android:background="@drawable/bg_drag_handle"
+                android:importantForAccessibility="no" />
+
             <LinearLayout
                 android:id="@+id/speechBubbleTitleContainer"
                 android:layout_width="match_parent"

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/controls/MapExtraButtons.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/controls/MapExtraButtons.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.screens.main.controls
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.runtime.Composable
@@ -15,7 +16,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun FilterOptionsButton(
+fun DownloadMapDataButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -25,11 +26,10 @@ fun FilterOptionsButton(
         contentPadding = 8.dp
     ) {
         Image(
-            imageVector = Icons.Default.Tune,
-            contentDescription = stringResource(Res.string.filter_options),
+            imageVector = Icons.Default.Download,
+            contentDescription = "Fetch map data",
             modifier = Modifier
                 .size(32.dp)
-
         )
     }
 }
@@ -56,8 +56,8 @@ fun ImageryListButton(
 
 @Preview
 @Composable
-private fun PreviewFilterOptionsButton() {
-    FilterOptionsButton(
+private fun PreviewDownloadMapDataButton() {
+    DownloadMapDataButton(
         onClick = {}
     )
 }


### PR DESCRIPTION
This pull request primarily refactors how filter options are managed and displayed in the main screen, shifting the state handling from local UI state to the `MainViewModel`. It also makes several code style improvements for readability and adjusts the bottom sheet behavior to improve the user experience. Below are the most important changes:

**Filter Options State Management and UI Refactor:**

* The logic for showing filter options has been moved from a local Compose state variable (`showFilterOptions`) to a `MutableStateFlow` in the `MainViewModel`, making the state shared and reactive across the UI. This includes updates in `MainScreen.kt`, `MainViewModel.kt`, and `MainViewModelImpl.kt`, and the addition of `showFilterOptions()` and `showFilterOptions` property in the view model. [[1]](diffhunk://#diff-e17f6fdbc567395ac6a70cbe552113808aea79dd572e02e7d85265b37c0a0224L174) [[2]](diffhunk://#diff-e17f6fdbc567395ac6a70cbe552113808aea79dd572e02e7d85265b37c0a0224L546-R544) [[3]](diffhunk://#diff-b2b95bc3918be6f8e18d7071962b27ee38ba826c3576cb1382876585650dbf63R117-R122) [[4]](diffhunk://#diff-04318c3223f330b7c20435e3ae51ba9e0460c1a65fac7a09c65a6757fff939a1R478-R484)

* The filter options button was removed from the bottom controls and is now triggered via the main menu button in the toolbar, further centralizing filter access and simplifying the control layout. [[1]](diffhunk://#diff-e17f6fdbc567395ac6a70cbe552113808aea79dd572e02e7d85265b37c0a0224L341-L348) [[2]](diffhunk://#diff-3578f07919a8dfbab2b3608653af79c4f6e56425958545ebd339ede9fd934aa1R359-R371)

**UI Layout and Controls:**

* The top-end controls in `MainScreen.kt` are restructured: the row containing overlay and menu buttons is uncommented and improved, and a new `DownloadMapDataButton` is added alongside the imagery layer button. [[1]](diffhunk://#diff-e17f6fdbc567395ac6a70cbe552113808aea79dd572e02e7d85265b37c0a0224L293-R322) [[2]](diffhunk://#diff-e17f6fdbc567395ac6a70cbe552113808aea79dd572e02e7d85265b37c0a0224L72-R73) [[3]](diffhunk://#diff-e17f6fdbc567395ac6a70cbe552113808aea79dd572e02e7d85265b37c0a0224R14)

**Bottom Sheet Behavior Enhancement:**

* The maximum height of bottom sheets is now capped at 85% of the screen height, ensuring that a portion of the map remains visible as a drag affordance, improving usability. [[1]](diffhunk://#diff-66c718c3a40f7b02c6221bac4827fafbcbf9abdb7e1ce9e706d6f6bcbed4fd50R66) [[2]](diffhunk://#diff-66c718c3a40f7b02c6221bac4827fafbcbf9abdb7e1ce9e706d6f6bcbed4fd50R100-R109)

**Code Style and Readability:**

* Several code blocks are reformatted for readability, including line breaks for method calls with multiple parameters and improved alignment of chained calls. [[1]](diffhunk://#diff-3578f07919a8dfbab2b3608653af79c4f6e56425958545ebd339ede9fd934aa1L381-R397) [[2]](diffhunk://#diff-3578f07919a8dfbab2b3608653af79c4f6e56425958545ebd339ede9fd934aa1L720-R734) [[3]](diffhunk://#diff-3578f07919a8dfbab2b3608653af79c4f6e56425958545ebd339ede9fd934aa1L1624-R1642) [[4]](diffhunk://#diff-3578f07919a8dfbab2b3608653af79c4f6e56425958545ebd339ede9fd934aa1L1789-R1808) [[5]](diffhunk://#diff-3578f07919a8dfbab2b3608653af79c4f6e56425958545ebd339ede9fd934aa1L1582-R1599)

**Import Cleanups:**

* Unused or misordered imports are cleaned up for consistency and clarity in `MainActivity.kt` and related files. [[1]](diffhunk://#diff-3578f07919a8dfbab2b3608653af79c4f6e56425958545ebd339ede9fd934aa1R47-L49) [[2]](diffhunk://#diff-3578f07919a8dfbab2b3608653af79c4f6e56425958545ebd339ede9fd934aa1R61-R67) [[3]](diffhunk://#diff-3578f07919a8dfbab2b3608653af79c4f6e56425958545ebd339ede9fd934aa1L109-R117) [[4]](diffhunk://#diff-f299600e7b0af8b96e50d4840640232983acaa973948e544deecb11397fdd248L5-R7)

These changes collectively improve state management, UI consistency, and code maintainability.


[Feature 4191](https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/4191): AVIV Android: Fix inconsistency between iOS and Android ASR : v1.2.8


[Screen_recording_20260819_165633.webm](https://github.com/user-attachments/assets/f1fff97d-4f43-445c-928c-4ae4a982baaa)

