### PR TITLE
Refactor toolbar layout and clean up unused imports in FollowModeScreen 

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/MainActivity.kt
@@ -1104,7 +1104,7 @@ class MainActivity :
             }
 
             else -> {
-                setIsNavigationMode(!mapFragment.isNavigationMode)
+                // setIsNavigationMode(!mapFragment.isNavigationMode)
             }
         }
     }

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/accessibility/FollowModeScreen.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/accessibility/FollowModeScreen.kt
@@ -1,6 +1,5 @@
 package de.westnordost.streetcomplete.screens.main.accessibility
 
-import android.content.Intent
 import android.location.Location
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -29,7 +28,6 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Navigation
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Undo
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
@@ -71,7 +69,6 @@ import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.quest.QuestKey
 import de.westnordost.streetcomplete.screens.main.MainViewModel
 import de.westnordost.streetcomplete.screens.main.map.MainMapFragment
-import de.westnordost.streetcomplete.screens.settings.SettingsActivity
 import de.westnordost.streetcomplete.screens.user.DottedDivider
 import de.westnordost.streetcomplete.screens.workspaces.CircularProgressWithText
 import de.westnordost.streetcomplete.util.ktx.toLatLon
@@ -141,7 +138,7 @@ fun FollowModeScreen(
             }
         }
 
-        if (showProgress.value){
+        if (showProgress.value) {
             CircularProgressWithText("Loading quests...")
         }
     }
@@ -377,23 +374,10 @@ private fun TopBar(onClose: () -> Unit) {
             style = MaterialTheme.typography.titleLarge.copy(
                 fontWeight = FontWeight.SemiBold
             ),
-            modifier = Modifier.weight(1f).padding(start = 16.dp)
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 16.dp)
         )
-
-        IconButton(onClick = {
-            context.startActivity(
-                Intent(
-
-                    context,
-                    SettingsActivity::class.java
-                )
-            )
-        }) {
-            Icon(
-                imageVector = Icons.Default.Settings,
-                contentDescription = "Open Settings"
-            )
-        }
 
         IconButton(onClick = onClose) {
             Icon(

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/HiddenQuestsSection.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/HiddenQuestsSection.kt
@@ -51,6 +51,8 @@ fun HiddenQuestsSection(
     onUnhideAll: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    if (items.isEmpty()) return
+
     var showUnhideAllConfirmation by remember { mutableStateOf(false) }
 
     Column(modifier) {
@@ -69,10 +71,7 @@ fun HiddenQuestsSection(
                     .padding(top = 4.dp)
                     .weight(1f),
             )
-            Button(
-                onClick = { showUnhideAllConfirmation = true },
-                enabled = items.isNotEmpty(),
-            ) {
+            Button(onClick = { showUnhideAllConfirmation = true }) {
                 Text("Unhide All")
             }
         }
@@ -86,22 +85,6 @@ fun HiddenQuestsSection(
             modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(bottom = 8.dp),
         ) {
-            if (items.isEmpty()) {
-                item {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 24.dp),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = "No hidden elements",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = LocalContentColor.current.copy(alpha = 0.6f),
-                        )
-                    }
-                }
-            }
             items(items, key = { it.key.listKey() }) { item ->
                 HiddenQuestRow(
                     item = item,

--- a/app/src/androidMain/res/layout/custom_toolbar.xml
+++ b/app/src/androidMain/res/layout/custom_toolbar.xml
@@ -63,6 +63,15 @@
         android:gravity="center_vertical|end"
         android:orientation="horizontal">
 
+        <de.westnordost.streetcomplete.screens.main.UploadButton
+            android:id="@+id/uploadButton"
+            style="@style/RoundPurpleButton"
+            android:layout_width="@dimen/map_button_size"
+            android:layout_height="@dimen/map_button_size"
+            android:contentDescription="@string/action_upload"
+            app:layout_constraintRight_toLeftOf="@+id/overlaysButton"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <ImageButton
             android:id="@+id/followModeButton"
             style="@style/RoundPurpleButton"
@@ -74,15 +83,6 @@
             android:visibility="visible"
             app:srcCompat="@drawable/outline_accessibility_24"
             app:tint="#2D0369" />
-
-        <de.westnordost.streetcomplete.screens.main.UploadButton
-            android:id="@+id/uploadButton"
-            style="@style/RoundPurpleButton"
-            android:layout_width="@dimen/map_button_size"
-            android:layout_height="@dimen/map_button_size"
-            android:contentDescription="@string/action_upload"
-            app:layout_constraintRight_toLeftOf="@+id/overlaysButton"
-            app:layout_constraintTop_toTopOf="parent" />
 
         <ImageButton
             android:id="@+id/mainMenuButton"


### PR DESCRIPTION
This pull request makes several UI and code improvements to the main activity, accessibility follow mode screen, quest selection settings, and the custom toolbar. The most significant changes include removing the settings button from the Follow Mode screen, refining the behavior and display of the Hidden Quests section, and rearranging the upload button in the toolbar layout.

**Accessibility & Navigation UI:**
* Removed the settings button from the Follow Mode screen's top bar, including related imports and intent code, to simplify the UI and reduce clutter. [[1]](diffhunk://#diff-58a4092316f3e7ad4b002b5009b68cb2736b96c9797b264f7e847d0929ea7692L32) [[2]](diffhunk://#diff-58a4092316f3e7ad4b002b5009b68cb2736b96c9797b264f7e847d0929ea7692L74) [[3]](diffhunk://#diff-58a4092316f3e7ad4b002b5009b68cb2736b96c9797b264f7e847d0929ea7692L380-L396)
* Commented out the code that toggles navigation mode in `MainActivity` for the default case, possibly to prevent unintended navigation mode switches.

**Quest Selection Settings:**
* Updated the `HiddenQuestsSection` to immediately return if there are no hidden quests, removing the "No hidden elements" placeholder and disabling the "Unhide All" button logic when unnecessary. [[1]](diffhunk://#diff-6eacdc2aa5dda528bf7d9ee20ba29ef2aaaf9a85f356fa8772be1f5680ff7064R54-R55) [[2]](diffhunk://#diff-6eacdc2aa5dda528bf7d9ee20ba29ef2aaaf9a85f356fa8772be1f5680ff7064L89-L104) [[3]](diffhunk://#diff-6eacdc2aa5dda528bf7d9ee20ba29ef2aaaf9a85f356fa8772be1f5680ff7064L72-R74)

**Toolbar Layout:**
* Rearranged the `UploadButton` position in `custom_toolbar.xml` by moving its declaration above the `followModeButton` and removing its previous duplicate placement, ensuring proper button order and layout consistency. [[1]](diffhunk://#diff-b0ef300c635ba16210cc6fe0e939b5f25e1fb0779deca6fc417e88fa2ed41994R66-R74) [[2]](diffhunk://#diff-b0ef300c635ba16210cc6fe0e939b5f25e1fb0779deca6fc417e88fa2ed41994L78-L86)