### PR TITLE
Update content descriptions and improve accessibility text

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/HiddenQuestsSection.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/quest_selection/HiddenQuestsSection.kt
@@ -1,12 +1,9 @@
 package de.westnordost.streetcomplete.screens.settings.quest_selection
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -15,14 +12,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Undo
 import androidx.compose.material3.Button
 import androidx.compose.material3.Divider
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,8 +35,8 @@ import de.westnordost.streetcomplete.resources.restore_dialog_message
 import de.westnordost.streetcomplete.ui.common.dialogs.ConfirmationDialog
 import org.jetbrains.compose.resources.stringResource
 
-/** Shows the list of individually hidden quest instances, with the option to unhide each one
- *  (by swiping it away) or all of them at once. Rendered below the quest type selection list */
+/** Shows the list of individually hidden quest instances, with a Restore button on each one and
+ *  the option to restore all of them at once. Rendered below the quest type selection list */
 @Composable
 fun HiddenQuestsSection(
     items: List<HiddenQuest>,
@@ -72,15 +65,9 @@ fun HiddenQuestsSection(
                     .weight(1f),
             )
             Button(onClick = { showUnhideAllConfirmation = true }) {
-                Text("Unhide All")
+                Text("Restore All")
             }
         }
-        Text(
-            text = "Swipe left on an item to unhide it and remove it from this list.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = LocalContentColor.current.copy(alpha = 0.6f),
-            modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
-        )
         LazyColumn(
             modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(bottom = 8.dp),
@@ -104,43 +91,19 @@ fun HiddenQuestsSection(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun HiddenQuestRow(item: HiddenQuest, onUnhide: () -> Unit) {
-    val dismissState = rememberSwipeToDismissBoxState(
-        confirmValueChange = { value ->
-            if (value == SwipeToDismissBoxValue.EndToStart) onUnhide()
-            true
-        }
-    )
-    SwipeToDismissBox(
-        state = dismissState,
-        enableDismissFromStartToEnd = false,
-        backgroundContent = {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.primaryContainer)
-                    .padding(horizontal = 20.dp),
-                contentAlignment = Alignment.CenterEnd,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Undo,
-                    contentDescription = "Unhide",
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                )
-            }
-        },
-    ) {
-        Column(
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surface)
+                .padding(start = 16.dp, end = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                    .weight(1f)
+                    .padding(vertical = 14.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
@@ -153,8 +116,15 @@ private fun HiddenQuestRow(item: HiddenQuest, onUnhide: () -> Unit) {
                     style = MaterialTheme.typography.bodyLarge,
                 )
             }
-            Divider()
+            IconButton(onClick = onUnhide) {
+                Icon(
+                    imageVector = Icons.Default.Undo,
+                    contentDescription = stringResource(Res.string.restore_confirmation),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
         }
+        Divider()
     }
 }
 

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/util/location/FineLocationManager.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/util/location/FineLocationManager.kt
@@ -20,9 +20,15 @@ import androidx.core.util.Consumer
 class FineLocationManager(context: Context, locationUpdateCallback: (Location) -> Unit) {
     private val locationManager = context.getSystemService<LocationManager>()!!
     private val mainExecutor = ContextCompat.getMainExecutor(context)
+    // getCurrentLocation() below asks GPS and Network providers separately, and each one calls
+    // this consumer independently as soon as it resolves - without the isBetterThan() check
+    // (same one the continuous locationListener already uses), a single getCurrentLocation()
+    // call fired locationUpdateCallback twice back-to-back, once per provider, double-triggering
+    // whatever the caller does per update (e.g. re-fetching workspaces from the network).
     private val currentLocationConsumer = Consumer<Location?> {
-        if (it != null) {
+        if (it != null && it.isBetterThan(lastLocation)) {
             if (!networkCancellationSignal.isCanceled && !gpsCancellationSignal.isCanceled) {
+                lastLocation = it
                 locationUpdateCallback(it)
             }
         }

--- a/app/src/androidMain/res/layout/custom_toolbar.xml
+++ b/app/src/androidMain/res/layout/custom_toolbar.xml
@@ -89,7 +89,7 @@
             style="@style/RoundPurpleButton"
             android:layout_width="@dimen/map_button_size"
             android:layout_height="@dimen/map_button_size"
-            android:contentDescription="@string/map_btn_menu"
+            android:contentDescription="@string/manage_quests"
             android:scaleType="centerInside"
             android:elevation="4dp"
             app:layout_constraintRight_toRightOf="parent"

--- a/app/src/androidMain/res/values-en/strings.xml
+++ b/app/src/androidMain/res/values-en/strings.xml
@@ -43,7 +43,7 @@ The info you enter is directly added to OpenStreetMap in your name, without the 
     <string name="compass">Compass</string>
 
     <string name="map_btn_menu">Menu</string>
-
+    <string name="manage_quests">Manage Quests</string>
     <string name="map_btn_gps_tracking">Follow me</string>
     <string name="turn_on_location_request">Location is off. Open Settings to turn it on now?</string>
     <string name="no_location_permission_warning_title">Location Permission</string>

--- a/app/src/androidMain/res/values/strings.xml
+++ b/app/src/androidMain/res/values/strings.xml
@@ -46,6 +46,7 @@ The info you enter is directly added to OpenStreetMap in your name, without the 
     <string name="compass">Compass</string>
 
     <string name="map_btn_menu">Menu</string>
+    <string name="manage_quests">Manage Quests</string>
 
     <string name="map_btn_gps_tracking">Follow me</string>
     <string name="turn_on_location_request">Location is off. Open Settings to turn it on now?</string>

--- a/app/src/commonMain/composeResources/values-en/strings.xml
+++ b/app/src/commonMain/composeResources/values-en/strings.xml
@@ -24,6 +24,7 @@ The info you enter is directly added to OpenStreetMap in your name, without the 
     <string name="action_about2">About</string>
     <string name="action_settings">Settings</string>
     <string name="action_overlays">Overlays</string>
+    <string name="action_imagery_list">Imagery List</string>
     <string name="user_profile">My Profile</string>
 
     <string name="team_mode">Enter Team Mode</string>

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/controls/MapExtraButtons.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/screens/main/controls/MapExtraButtons.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import de.westnordost.streetcomplete.resources.Res
+import de.westnordost.streetcomplete.resources.action_imagery_list
 import de.westnordost.streetcomplete.resources.action_overlays
 import de.westnordost.streetcomplete.resources.filter_options
 import org.jetbrains.compose.resources.stringResource
@@ -27,7 +28,7 @@ fun DownloadMapDataButton(
     ) {
         Image(
             imageVector = Icons.Default.Download,
-            contentDescription = "Fetch map data",
+            contentDescription = "Fetch the latest quests for this area",
             modifier = Modifier
                 .size(32.dp)
         )
@@ -46,7 +47,7 @@ fun ImageryListButton(
     ) {
         Image(
             imageVector = Icons.Default.Layers,
-            contentDescription = stringResource(Res.string.action_overlays),
+            contentDescription = stringResource(Res.string.action_imagery_list),
             modifier = Modifier
                 .size(32.dp)
 


### PR DESCRIPTION
This pull request improves the user interface and accessibility of quest management features, clarifies button labels and descriptions, and fixes a location update bug. The most notable changes include replacing swipe-to-unhide with explicit restore buttons for hidden quests, updating various button text and content descriptions for clarity, and ensuring location updates are not triggered multiple times unnecessarily.

**Quest Management UI Improvements:**
* Replaced swipe-to-unhide with explicit "Restore" buttons for each hidden quest and a "Restore All" button, making the action clearer and more accessible in `HiddenQuestsSection.kt`. The UI now uses an `IconButton` for restoring instead of swipe gestures, and instructional text about swiping was removed. [[1]](diffhunk://#diff-6eacdc2aa5dda528bf7d9ee20ba29ef2aaaf9a85f356fa8772be1f5680ff7064L3-L9) [[2]](diffhunk://#diff-6eacdc2aa5dda528bf7d9ee20ba29ef2aaaf9a85f356fa8772be1f5680ff7064L18-L25) [[3]](diffhunk://#diff-6eacdc2aa5dda528bf7d9ee20ba29ef2aaaf9a85f356fa8772be1f5680ff7064L45-R39) [[4]](diffhunk://#diff-6eacdc2aa5dda528bf7d9ee20ba29ef2aaaf9a85f356fa8772be1f5680ff7064L75-L83) [[5]](diffhunk://#diff-6eacdc2aa5dda528bf7d9ee20ba29ef2aaaf9a85f356fa8772be1f5680ff7064L107-R106) [[6]](diffhunk://#diff-6eacdc2aa5dda528bf7d9ee20ba29ef2aaaf9a85f356fa8772be1f5680ff7064L156-R128)

**Accessibility and Text Updates:**
* Updated button and icon content descriptions and labels for clarity, including changing the "Menu" button to "Manage Quests" and improving descriptions for map data and imagery list buttons. New string resources were added where needed. [[1]](diffhunk://#diff-b0ef300c635ba16210cc6fe0e939b5f25e1fb0779deca6fc417e88fa2ed41994L92-R92) [[2]](diffhunk://#diff-4bb3a62a06c9c21211b186eba92cfef3982e37aa775f92abea86d4683156a3a3L46-R46) [[3]](diffhunk://#diff-e52e1bac6d4f03275655839a28f712a920abb5126d2798b2173158418f696d0fR49) [[4]](diffhunk://#diff-8209a9a1aa5da5628df3a9d32f6bfa2826ddb839e5ffb8a23ec7135a349e35b4L30-R31) [[5]](diffhunk://#diff-8209a9a1aa5da5628df3a9d32f6bfa2826ddb839e5ffb8a23ec7135a349e35b4L49-R50) [[6]](diffhunk://#diff-576e2607f727c0a511595976b5497d2760d318a31771c880dd6336caefe20979R27)

**Bug Fixes:**
* Fixed a bug in `FineLocationManager` where the location update callback could be triggered twice in quick succession by ensuring only better locations are reported, preventing redundant updates.