### PR TITLE
Add logging for Ktor client and handle photo upload exceptions in sync

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/ApplicationModule.kt
@@ -171,6 +171,14 @@ val appModule = module {
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
             }
+            install(Logging) {
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        Log.d("KtorClient", message) // Avoid System.err
+                    }
+                }
+                level = LogLevel.ALL
+            }
             install(HttpRequestRetry) {
                 retryOnServerErrors(maxRetries = 3)
                 retryOnException(maxRetries = 3, retryOnTimeout = true)

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/karta_view/KartaViewApiClient.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/karta_view/KartaViewApiClient.kt
@@ -1,6 +1,7 @@
 package de.westnordost.streetcomplete.data.karta_view
 
 import de.westnordost.streetcomplete.data.karta_view.domain.model.CreateSequenceResponse
+import de.westnordost.streetcomplete.data.karta_view.domain.model.ImageUploadResponse
 import de.westnordost.streetcomplete.data.karta_view.domain.model.PhotoLookupResponse
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.preferences.Preferences
@@ -33,10 +34,15 @@ class KartaViewApiClient(
      *  uploaded image, in the same order.
      *
      *  @throws KartaViewException naming the step that failed */
-    suspend fun upload(imagePaths: List<String>, position: LatLon, bearing: Float = 0f): List<String> {
+    suspend fun upload(
+        imagePaths: List<String>,
+        position: LatLon,
+        bearing: Float = 0f,
+    ): List<String> {
         val images = imagePaths.mapNotNull { path ->
             val file = Path(path)
-            if (fileSystem.exists(file)) fileSystem.source(file).buffered().readByteArray() else null
+            if (fileSystem.exists(file)) fileSystem.source(file).buffered()
+                .readByteArray() else null
         }
         return uploadImages(images, position, bearing)
     }
@@ -46,14 +52,18 @@ class KartaViewApiClient(
      *  image, in the same order.
      *
      *  @throws KartaViewException naming the step that failed */
-    suspend fun uploadImages(images: List<ByteArray>, position: LatLon, bearing: Float = 0f): List<String> {
+    suspend fun uploadImages(
+        images: List<ByteArray>,
+        position: LatLon,
+        bearing: Float = 0f,
+    ): List<String> {
         if (images.isEmpty()) return emptyList()
         val sequenceId = createSequence()
-        images.forEachIndexed { index, image ->
+        val photoIds = images.mapIndexed { index, image ->
             uploadPhoto(sequenceId, index + 1, image, position, bearing)
         }
         closeSequence(sequenceId)
-        return List(images.size) { index -> getPhotoLthUrl(sequenceId, index + 1) }
+        return photoIds.map { photoId -> getPhotoLthUrl(photoId) }
     }
 
     private suspend fun createSequence(): String {
@@ -78,7 +88,7 @@ class KartaViewApiClient(
         image: ByteArray,
         position: LatLon,
         bearing: Float,
-    ) {
+    ): String {
         val response = httpClient.post(BASE_URL + "1.0/photo/") {
             setBody(MultiPartFormDataContent(formData {
                 append("access_token", prefs.kartaViewAccessToken)
@@ -96,8 +106,12 @@ class KartaViewApiClient(
             throw KartaViewException(
                 "Failed to upload image to KartaView. Please try again later " + response.status
             )
+        } else {
+            val imageResponse = response.body<ImageUploadResponse>()
+            val imageId = imageResponse.osv.photo.id
+            Log.d(TAG, "Image $sequenceIndex uploaded to sequence $sequenceId and photo ID $imageId")
+            return imageId
         }
-        Log.d(TAG, "Image $sequenceIndex uploaded to sequence $sequenceId")
     }
 
     private suspend fun closeSequence(sequenceId: String) {
@@ -115,7 +129,7 @@ class KartaViewApiClient(
         Log.d(TAG, "Sequence closed: ${response.body<CreateSequenceResponse>().status.httpMessage}")
     }
 
-    private suspend fun getPhotoLthUrl(sequenceId: String, sequenceIndex: Int): String {
+    private suspend fun getPhotoLthUrl(photoId: String): String {
         // KartaView's lookup endpoint is eventually consistent - right after closeSequence()
         // succeeds, a lookup for the photo that was just uploaded can still come back 200 OK
         // with no data yet because the server hasn't indexed it. That is not a real failure, so
@@ -125,13 +139,11 @@ class KartaViewApiClient(
         var attempt = 1
         var delayMillis = 1000L
         while (true) {
-            val response = httpClient.get(BASE_URL + "2.0/photo/") {
+            val response = httpClient.get(BASE_URL + "2.0/photo/$photoId") {
                 parameter("access_token", prefs.kartaViewAccessToken)
-                parameter("sequenceId", sequenceId)
-                parameter("sequenceIndex", sequenceIndex)
             }
             if (response.status == HttpStatusCode.OK) {
-                val url = response.body<PhotoLookupResponse>().result?.data?.firstOrNull()?.imageLthUrl
+                val url = response.body<PhotoLookupResponse>().result?.data?.imageLthUrl
                 if (url != null) return url
             }
             if (attempt >= MAX_PHOTO_LOOKUP_ATTEMPTS) {
@@ -141,7 +153,7 @@ class KartaViewApiClient(
             }
             Log.w(
                 TAG,
-                "Photo lookup for sequence $sequenceId#$sequenceIndex returned no data yet " +
+                "Photo lookup for photo $photoId returned no data yet " +
                     "(attempt $attempt/$MAX_PHOTO_LOOKUP_ATTEMPTS), retrying in ${delayMillis}ms"
             )
             delay(delayMillis)
@@ -153,6 +165,7 @@ class KartaViewApiClient(
     companion object {
         private const val TAG = "KartaViewApiClient"
         private const val BASE_URL = "https://api.openstreetcam.org/"
+
         // 1s, 2s, 4s, 8s between the 5 attempts - covers the observed sub-second indexing lag
         // with headroom, without blowing up the upload worker's run time if it takes longer.
         private const val MAX_PHOTO_LOOKUP_ATTEMPTS = 5

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/karta_view/domain/model/Photo.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/karta_view/domain/model/Photo.kt
@@ -6,6 +6,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class Photo(
+    @SerialName("id")
+    val id : String,
     @SerialName("path")
     val path: String,
     @SerialName("photoName")

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/karta_view/domain/model/PhotoLookupResponse.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/karta_view/domain/model/PhotoLookupResponse.kt
@@ -9,7 +9,7 @@ data class PhotoLookupResponse(
 
 @Serializable
 data class PhotoLookupResult(
-    val data: List<PhotoLookup> = emptyList()
+    val data: PhotoLookup? = null
 )
 
 @Serializable

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osm/edits/upload/ElementEditsUploader.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.data.osm.edits.upload
 
 import de.westnordost.streetcomplete.data.ConflictException
 import de.westnordost.streetcomplete.data.karta_view.KartaViewApiClient
+import de.westnordost.streetcomplete.data.karta_view.KartaViewException
 import de.westnordost.streetcomplete.data.osm.edits.DiscardedEditNotice
 import de.westnordost.streetcomplete.data.osm.edits.DiscardedEditNoticesController
 import de.westnordost.streetcomplete.data.osm.edits.ElementEdit
@@ -52,10 +53,19 @@ class ElementEditsUploader(
         while (true) {
             val edit = elementEditsController.getOldestUnsynced() ?: break
             val getIdProvider: () -> ElementIdProvider = { elementEditsController.getIdProvider(edit.id) }
-            /* the sync of local change -> API and its response should not be cancellable because
-             * otherwise an inconsistency in the data would occur. E.g. no "star" for an uploaded
-             * change, a change could be uploaded twice etc */
-            withContext(scope.coroutineContext) { uploadEdit(edit, getIdProvider) }
+            try {
+                /* the sync of local change -> API and its response should not be cancellable
+                 * because otherwise an inconsistency in the data would occur. E.g. no "star" for
+                 * an uploaded change, a change could be uploaded twice etc */
+                withContext(scope.coroutineContext) { uploadEdit(edit, getIdProvider) }
+            } catch (e: KartaViewException) {
+                /* the edit's photos failed to upload (plain network failure) - leave the edit
+                 * unsynced for the next sync attempt instead of letting this bubble up and abort
+                 * uploading of any other edits still queued, e.g. note edits (see
+                 * uploadPendingPhotos KDoc) */
+                Log.w(TAG, "Failed to upload photos, will retry on next sync: ${e.message}")
+                break
+            }
         }
     } }
 

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsUploader.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/data/osmnotes/edits/NoteEditsUploader.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.data.osmnotes.edits
 import de.westnordost.streetcomplete.ApplicationConstants
 import de.westnordost.streetcomplete.data.ConflictException
 import de.westnordost.streetcomplete.data.karta_view.KartaViewApiClient
+import de.westnordost.streetcomplete.data.karta_view.KartaViewException
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osmnotes.NoteController
 import de.westnordost.streetcomplete.data.osmnotes.NotesApiClient
@@ -63,10 +64,17 @@ class NoteEditsUploader(
     private suspend fun uploadEdits() {
         while (true) {
             val edit = noteEditsController.getOldestUnsynced() ?: break
-            /* the sync of local change -> API and its response should not be cancellable because
-             * otherwise an inconsistency in the data would occur. E.g. a note could be uploaded
-             * twice  */
-            withContext(scope.coroutineContext) { uploadEdit(edit) }
+            try {
+                /* the sync of local change -> API and its response should not be cancellable
+                 * because otherwise an inconsistency in the data would occur. E.g. a note could
+                 * be uploaded twice */
+                withContext(scope.coroutineContext) { uploadEdit(edit) }
+            } catch (e: KartaViewException) {
+                // photo upload failed (plain network failure) - leave the note edit unsynced for
+                // the next sync attempt instead of aborting the whole upload (see class KDoc)
+                Log.w(TAG, "Failed to upload photos, will retry on next sync: ${e.message}")
+                break
+            }
         }
     }
 


### PR DESCRIPTION
This pull request introduces several important improvements to the KartaView photo upload integration and its error handling, as well as enhanced logging for network requests. The main changes include switching from sequence-based to photo ID-based lookups for uploaded images, updating data models to match the new API responses, and improving the robustness of upload error handling to avoid aborting all uploads on a single failure.

**KartaView API integration improvements:**

* Changed the photo upload and lookup process in `KartaViewApiClient` to use photo IDs returned by the upload API, rather than relying on sequence and index, for more reliable and future-proof image retrieval. This includes updating the `uploadImages`, `uploadPhoto`, and `getPhotoLthUrl` methods to work with photo IDs instead of sequence indices. [[1]](diffhunk://#diff-0e252244e11d7044d6936dcf0813e9ff7d3b45cea6297d286db4b124b16eedb1L49-R66) [[2]](diffhunk://#diff-0e252244e11d7044d6936dcf0813e9ff7d3b45cea6297d286db4b124b16eedb1L81-R91) [[3]](diffhunk://#diff-0e252244e11d7044d6936dcf0813e9ff7d3b45cea6297d286db4b124b16eedb1R109-L100) [[4]](diffhunk://#diff-0e252244e11d7044d6936dcf0813e9ff7d3b45cea6297d286db4b124b16eedb1L118-R132) [[5]](diffhunk://#diff-0e252244e11d7044d6936dcf0813e9ff7d3b45cea6297d286db4b124b16eedb1L128-R146) [[6]](diffhunk://#diff-0e252244e11d7044d6936dcf0813e9ff7d3b45cea6297d286db4b124b16eedb1L144-R156)
* Updated the `Photo` and `PhotoLookupResponse` data models to align with the new API responses: `Photo` now includes an `id` field, and `PhotoLookupResult.data` is now a nullable single object instead of a list. [[1]](diffhunk://#diff-2b16bab2e85905755e69b1b2f8c0522fd58cd019b7dc2d67e2d2991821f61ccaR9-R10) [[2]](diffhunk://#diff-8cd385bd9e1742b4437672875fc121666ebf3698dbd5fa1b637cf0813d38c4e4L12-R12)

**Error handling and upload robustness:**

* Improved error handling in both `ElementEditsUploader` and `NoteEditsUploader` to catch `KartaViewException` during photo uploads. If a photo upload fails, the specific edit is left unsynced for the next attempt, and the upload process for other edits continues, preventing a single failure from aborting all queued uploads. [[1]](diffhunk://#diff-7135fbf39cefa4666b599a271077a105114885ac69cc0d598389a929e84869eaL55-R68) [[2]](diffhunk://#diff-9d92e75de29182d83b108457838696e059ae8de8f6aad450fd93b7dcd69901e7L66-R77)

**Logging and developer experience:**

* Added Ktor HTTP client logging to Android using the `Logging` plugin, with logs directed to Android's `Log.d` instead of `System.err` for better log visibility and filtering.

These changes collectively make photo uploads to KartaView more reliable, easier to debug, and less prone to failures that block other queued uploads.